### PR TITLE
[BE_FEAT] 단일 포켓몬 정보 불러오는 API

### DIFF
--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/domain/PokemonAbility.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/domain/PokemonAbility.java
@@ -30,6 +30,6 @@ public class PokemonAbility {
     @Column(name = "short_description", nullable = false)
     private String shortDescription;
 
-    @OneToMany(mappedBy = "pokemon_ability", fetch = FetchType.LAZY)
-    private List<PokemonAbilityMapping> pokemonAbilityMapping;
+    @OneToMany(mappedBy = "pokemonAbility", fetch = FetchType.LAZY)
+    private List<PokemonAbilityMapping> pokemonAbilityMappings;
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/global/exception/ErrorMessage.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/global/exception/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.pokerogue.helper.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessage {
+    POKEMON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 포켓몬을 찾지 못했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/global/exception/GlobalCustomException.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/global/exception/GlobalCustomException.java
@@ -1,0 +1,17 @@
+package com.pokerogue.helper.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class GlobalCustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+
+    public GlobalCustomException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.httpStatus = errorMessage.getHttpStatus();
+    }
+}

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/global/exception/PokemonExceptionHandler.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/global/exception/PokemonExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.pokerogue.helper.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class PokemonExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(GlobalCustomException.class)
+    public ResponseEntity<String> handleViolationException(GlobalCustomException e) {
+        log.error("error message : {}", e.getMessage());
+
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(e.getMessage());
+    }
+}

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/controller/PokemonController.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/controller/PokemonController.java
@@ -1,11 +1,13 @@
 package com.pokerogue.helper.pokemon.controller;
 
+import com.pokerogue.helper.pokemon.dto.PokedexResponse;
 import com.pokerogue.helper.pokemon.dto.PokemonResponse;
 import com.pokerogue.helper.pokemon.service.PokemonService;
 import com.pokerogue.helper.util.dto.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,5 +19,10 @@ public class PokemonController {
     @GetMapping("/api/v1/pokemons")
     public ApiResponse<List<PokemonResponse>> pokemonList() {
         return new ApiResponse<>("포켓몬 리스트 불러오기에 성공했습니다.", pokemonService.findPokemons());
+    }
+
+    @GetMapping("/api/v1/pokemon/{id}")
+    public ApiResponse<PokedexResponse> pokedexDetails(@PathVariable("id") Long id) {
+        return new ApiResponse<>("포켓몬 정보 불러오기에 성공했습니다.", pokemonService.findPokedexDetails(id));
     }
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/domain/PokemonAbilityMapping.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/domain/PokemonAbilityMapping.java
@@ -29,4 +29,8 @@ public class PokemonAbilityMapping {
     @ManyToOne
     @JoinColumn(name = "pokemon_ability_id", nullable = false)
     private PokemonAbility pokemonAbility;
+
+    public String getPokemonAbilityName() {
+        return pokemonAbility.getName();
+    }
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/dto/PokedexResponse.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/dto/PokedexResponse.java
@@ -1,0 +1,16 @@
+package com.pokerogue.helper.pokemon.dto;
+
+import com.pokerogue.helper.pokemon.domain.Pokemon;
+import com.pokerogue.helper.type.dto.PokemonTypeResponse;
+import java.util.List;
+
+public record PokedexResponse(Long pokedexNumber, String name, String pokemonImage,
+                              List<PokemonTypeResponse> pokemonTypeResponses, List<String> pokemonAbilityNames,
+                              Integer weight, Integer height) {
+
+    public static PokedexResponse of(Pokemon pokemon, List<PokemonTypeResponse> pokemonTypeResponses,
+                                     List<String> pokemonAbilityNames) {
+        return new PokedexResponse(pokemon.getPokemonNumber(), pokemon.getName(), pokemon.getImage(),
+                pokemonTypeResponses, pokemonAbilityNames, pokemon.getWeight(), pokemon.getHeight());
+    }
+}

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/repository/PokemonRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/repository/PokemonRepository.java
@@ -2,7 +2,15 @@ package com.pokerogue.helper.pokemon.repository;
 
 
 import com.pokerogue.helper.pokemon.domain.Pokemon;
+import java.util.Optional;
+import lombok.NonNull;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PokemonRepository extends JpaRepository<Pokemon, Long> {
+
+    @Override
+    @NonNull
+    @EntityGraph(attributePaths = {"pokemonAbilityMappings"})
+    Optional<Pokemon> findById(@NonNull Long id);
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/service/PokemonService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/service/PokemonService.java
@@ -1,9 +1,14 @@
 package com.pokerogue.helper.pokemon.service;
 
+import com.pokerogue.helper.global.exception.ErrorMessage;
+import com.pokerogue.helper.global.exception.GlobalCustomException;
 import com.pokerogue.helper.pokemon.domain.Pokemon;
+import com.pokerogue.helper.pokemon.domain.PokemonAbilityMapping;
 import com.pokerogue.helper.pokemon.domain.PokemonTypeMapping;
+import com.pokerogue.helper.pokemon.dto.PokedexResponse;
 import com.pokerogue.helper.pokemon.dto.PokemonResponse;
 import com.pokerogue.helper.pokemon.repository.PokemonRepository;
+import com.pokerogue.helper.type.dto.PokemonTypeResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,5 +35,27 @@ public class PokemonService {
                 .toList();
 
         return PokemonResponse.of(pokemon, pokemonTypeImages);
+    }
+
+    public PokedexResponse findPokedexDetails(Long id) {
+        Pokemon pokemon = pokemonRepository.findById(id)
+                .orElseThrow(() -> new GlobalCustomException(ErrorMessage.POKEMON_NOT_FOUND));
+
+        return toPokedexResponse(pokemon);
+    }
+
+    private PokedexResponse toPokedexResponse(Pokemon pokemon) {
+        List<PokemonTypeMapping> pokemonTypeMappings = pokemon.getPokemonTypeMappings();
+        List<PokemonAbilityMapping> pokemonAbilityMappings = pokemon.getPokemonAbilityMappings();
+
+        List<PokemonTypeResponse> pokemonTypeResponses = pokemonTypeMappings.stream()
+                .map(PokemonTypeMapping::getPokemonType)
+                .map(PokemonTypeResponse::from)
+                .toList();
+        List<String> pokemonAbilityNames = pokemonAbilityMappings.stream()
+                .map(PokemonAbilityMapping::getPokemonAbilityName)
+                .toList();
+
+        return PokedexResponse.of(pokemon, pokemonTypeResponses, pokemonAbilityNames);
     }
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/type/dto/PokemonTypeResponse.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/type/dto/PokemonTypeResponse.java
@@ -1,0 +1,10 @@
+package com.pokerogue.helper.type.dto;
+
+import com.pokerogue.helper.type.domain.PokemonType;
+
+public record PokemonTypeResponse(String pokemonTypeName, String pokemonTypeLogo) {
+
+    public static PokemonTypeResponse from(PokemonType pokemonType) {
+        return new PokemonTypeResponse(pokemonType.getName(), pokemonType.getCircleImage());
+    }
+}


### PR DESCRIPTION

## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [x] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #17 

 - [ ] 단일 포켓몬 정보를 불러오는 API .
 - [ ] 타입과 속성 정보도 함께 불러온다.

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [ ] 있음
- [x] 없음

```

```