### PR TITLE
[AN_UI] TypeChip component, CommonBindingAdapter, Serializable, Parcelable Util 함수들 추가

### DIFF
--- a/android/app/src/main/java/poke/rogue/helper/presentation/type/typeselection/TypeSelectionBottomSheetFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/type/typeselection/TypeSelectionBottomSheetFragment.kt
@@ -1,7 +1,6 @@
 package poke.rogue.helper.presentation.type.typeselection
 
 import android.content.Context
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View

--- a/android/app/src/main/java/poke/rogue/helper/presentation/type/typeselection/TypeSelectionBottomSheetFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/type/typeselection/TypeSelectionBottomSheetFragment.kt
@@ -15,6 +15,8 @@ import poke.rogue.helper.presentation.type.TypeViewModel
 import poke.rogue.helper.presentation.type.model.SelectorType
 import poke.rogue.helper.presentation.type.model.TypeUiModel
 import poke.rogue.helper.presentation.type.model.TypeUiModel.Companion.toUiModel
+import poke.rogue.helper.presentation.util.fragment.withArgs
+import poke.rogue.helper.presentation.util.serializable
 import poke.rogue.helper.presentation.util.view.GridSpacingItemDecoration
 import poke.rogue.helper.presentation.util.view.dp
 
@@ -22,11 +24,8 @@ class TypeSelectionBottomSheetFragment : BottomSheetDialogFragment() {
     private var _binding: FragmentTypeChoiceBottomSheetBinding? = null
     private val binding get() = requireNotNull(_binding)
     private val selectorType: SelectorType by lazy {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            arguments?.getSerializable(KEY_SELECTION_TYPE, SelectorType::class.java)
-        } else {
-            arguments?.getSerializable(KEY_SELECTION_TYPE) as? SelectorType
-        } ?: throw IllegalArgumentException("InValid TypeSelector")
+        arguments?.serializable<SelectorType>(KEY_SELECTION_TYPE)
+            ?: error("InValid TypeSelector")
     }
     private lateinit var sharedViewModel: TypeViewModel
 
@@ -101,8 +100,8 @@ class TypeSelectionBottomSheetFragment : BottomSheetDialogFragment() {
         private const val KEY_SELECTION_TYPE = "selection_type"
 
         fun newInstance(selectorType: SelectorType): TypeSelectionBottomSheetFragment {
-            return TypeSelectionBottomSheetFragment().apply {
-                arguments = Bundle().apply { putSerializable(KEY_SELECTION_TYPE, selectorType) }
+            return TypeSelectionBottomSheetFragment().withArgs {
+                putSerializable(KEY_SELECTION_TYPE, selectorType)
             }
         }
     }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/type/view/TypeChip.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/type/view/TypeChip.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.annotation.Dimension
+import androidx.core.content.res.use
 import androidx.databinding.BindingAdapter
 import poke.rogue.helper.R
 import poke.rogue.helper.databinding.ItemTypeBinding

--- a/android/app/src/main/java/poke/rogue/helper/presentation/type/view/TypeChip.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/type/view/TypeChip.kt
@@ -11,7 +11,7 @@ import poke.rogue.helper.databinding.ItemTypeBinding
 import poke.rogue.helper.presentation.type.model.TypeUiModel
 import poke.rogue.helper.presentation.util.view.px
 
-class TypeItemView
+class TypeChip
     @JvmOverloads
     constructor(
         context: Context,
@@ -22,13 +22,13 @@ class TypeItemView
             ItemTypeBinding.inflate(LayoutInflater.from(context), this, true)
 
         init {
-            val attributes = context.obtainStyledAttributes(attrs, R.styleable.TypeItemView)
+            val attributes = context.obtainStyledAttributes(attrs, R.styleable.TypeChip)
             attributes.use {
-                val iconSize = attributes.getDimension(R.styleable.TypeItemView_iconSize, 18f)
-                val spacing = attributes.getDimension(R.styleable.TypeItemView_spacing, 7f)
-                val nameSize = attributes.getDimension(R.styleable.TypeItemView_nameSize, 8f).px
+                val iconSize = attributes.getDimension(R.styleable.TypeChip_iconSize, 18f)
+                val spacing = attributes.getDimension(R.styleable.TypeChip_spacing, 7f)
+                val nameSize = attributes.getDimension(R.styleable.TypeChip_nameSize, 8f).px
                 val isEmptyBackGround =
-                    attributes.getBoolean(R.styleable.TypeItemView_emptyBackGround, false)
+                    attributes.getBoolean(R.styleable.TypeChip_emptyBackGround, true)
                 initViews(iconSize, spacing, nameSize, isEmptyBackGround)
             }
         }
@@ -53,7 +53,7 @@ class TypeItemView
             @JvmStatic
             @BindingAdapter("type")
             fun setTypeName(
-                view: TypeItemView,
+                view: TypeChip,
                 typeUiModel: TypeUiModel,
             ) {
                 view.binding.type = typeUiModel

--- a/android/app/src/main/java/poke/rogue/helper/presentation/type/view/TypeItemView.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/type/view/TypeItemView.kt
@@ -1,0 +1,58 @@
+package poke.rogue.helper.presentation.type.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import androidx.annotation.Dimension
+import androidx.databinding.BindingAdapter
+import poke.rogue.helper.R
+import poke.rogue.helper.databinding.ItemTypeBinding
+import poke.rogue.helper.presentation.type.model.TypeUiModel
+import poke.rogue.helper.presentation.util.view.px
+
+class TypeItemView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr) {
+
+    private val binding: ItemTypeBinding =
+        ItemTypeBinding.inflate(LayoutInflater.from(context), this, true)
+
+    init {
+        val attributes = context.obtainStyledAttributes(attrs, R.styleable.TypeItemView)
+        attributes.use {
+            val iconSize = attributes.getDimension(R.styleable.TypeItemView_iconSize, 18f)
+            val spacing = attributes.getDimension(R.styleable.TypeItemView_spacing, 7f)
+            val nameSize = attributes.getDimension(R.styleable.TypeItemView_nameSize, 8f).px
+            val isEmptyBackGround =
+                attributes.getBoolean(R.styleable.TypeItemView_emptyBackGround, false)
+            initViews(iconSize, spacing, nameSize, isEmptyBackGround)
+        }
+    }
+
+    private fun initViews(
+        @Dimension iconSize: Float,
+        @Dimension spacing: Float,
+        @Dimension nameSize: Float,
+        isEmptyBackGround: Boolean
+    ) = with(binding) {
+        orientation = HORIZONTAL
+        ivTypeNameIcon.layoutParams.apply {
+            width = iconSize.toInt()
+            height = iconSize.toInt()
+        }
+        spaceType.layoutParams.width = spacing.toInt()
+        tvTypeName.textSize = nameSize
+        isEmptyBackground = isEmptyBackGround
+    }
+
+    companion object {
+        @JvmStatic
+        @BindingAdapter("type")
+        fun setTypeName(view: TypeItemView, typeUiModel: TypeUiModel) {
+            view.binding.type = typeUiModel
+        }
+    }
+}

--- a/android/app/src/main/java/poke/rogue/helper/presentation/type/view/TypeItemView.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/type/view/TypeItemView.kt
@@ -11,48 +11,52 @@ import poke.rogue.helper.databinding.ItemTypeBinding
 import poke.rogue.helper.presentation.type.model.TypeUiModel
 import poke.rogue.helper.presentation.util.view.px
 
-class TypeItemView @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
-) : LinearLayout(context, attrs, defStyleAttr) {
+class TypeItemView
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : LinearLayout(context, attrs, defStyleAttr) {
+        private val binding: ItemTypeBinding =
+            ItemTypeBinding.inflate(LayoutInflater.from(context), this, true)
 
-    private val binding: ItemTypeBinding =
-        ItemTypeBinding.inflate(LayoutInflater.from(context), this, true)
+        init {
+            val attributes = context.obtainStyledAttributes(attrs, R.styleable.TypeItemView)
+            attributes.use {
+                val iconSize = attributes.getDimension(R.styleable.TypeItemView_iconSize, 18f)
+                val spacing = attributes.getDimension(R.styleable.TypeItemView_spacing, 7f)
+                val nameSize = attributes.getDimension(R.styleable.TypeItemView_nameSize, 8f).px
+                val isEmptyBackGround =
+                    attributes.getBoolean(R.styleable.TypeItemView_emptyBackGround, false)
+                initViews(iconSize, spacing, nameSize, isEmptyBackGround)
+            }
+        }
 
-    init {
-        val attributes = context.obtainStyledAttributes(attrs, R.styleable.TypeItemView)
-        attributes.use {
-            val iconSize = attributes.getDimension(R.styleable.TypeItemView_iconSize, 18f)
-            val spacing = attributes.getDimension(R.styleable.TypeItemView_spacing, 7f)
-            val nameSize = attributes.getDimension(R.styleable.TypeItemView_nameSize, 8f).px
-            val isEmptyBackGround =
-                attributes.getBoolean(R.styleable.TypeItemView_emptyBackGround, false)
-            initViews(iconSize, spacing, nameSize, isEmptyBackGround)
+        private fun initViews(
+            @Dimension iconSize: Float,
+            @Dimension spacing: Float,
+            @Dimension nameSize: Float,
+            isEmptyBackGround: Boolean,
+        ) = with(binding) {
+            orientation = HORIZONTAL
+            ivTypeNameIcon.layoutParams.apply {
+                width = iconSize.toInt()
+                height = iconSize.toInt()
+            }
+            spaceType.layoutParams.width = spacing.toInt()
+            tvTypeName.textSize = nameSize
+            isEmptyBackground = isEmptyBackGround
+        }
+
+        companion object {
+            @JvmStatic
+            @BindingAdapter("type")
+            fun setTypeName(
+                view: TypeItemView,
+                typeUiModel: TypeUiModel,
+            ) {
+                view.binding.type = typeUiModel
+            }
         }
     }
-
-    private fun initViews(
-        @Dimension iconSize: Float,
-        @Dimension spacing: Float,
-        @Dimension nameSize: Float,
-        isEmptyBackGround: Boolean
-    ) = with(binding) {
-        orientation = HORIZONTAL
-        ivTypeNameIcon.layoutParams.apply {
-            width = iconSize.toInt()
-            height = iconSize.toInt()
-        }
-        spaceType.layoutParams.width = spacing.toInt()
-        tvTypeName.textSize = nameSize
-        isEmptyBackground = isEmptyBackGround
-    }
-
-    companion object {
-        @JvmStatic
-        @BindingAdapter("type")
-        fun setTypeName(view: TypeItemView, typeUiModel: TypeUiModel) {
-            view.binding.type = typeUiModel
-        }
-    }
-}

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/BundleExtensions.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/BundleExtensions.kt
@@ -1,0 +1,14 @@
+package poke.rogue.helper.presentation.util
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.core.os.BundleCompat
+import java.io.Serializable
+
+inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? {
+    return BundleCompat.getParcelable(this, key, T::class.java)
+}
+
+inline fun <reified T: Serializable> Bundle.serializable(key: String): T? {
+    return BundleCompat.getSerializable(this, key, T::class.java)
+}

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/BundleExtensions.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/BundleExtensions.kt
@@ -9,6 +9,6 @@ inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? {
     return BundleCompat.getParcelable(this, key, T::class.java)
 }
 
-inline fun <reified T: Serializable> Bundle.serializable(key: String): T? {
+inline fun <reified T : Serializable> Bundle.serializable(key: String): T? {
     return BundleCompat.getSerializable(this, key, T::class.java)
 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/IntentExensions.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/IntentExensions.kt
@@ -1,0 +1,14 @@
+package poke.rogue.helper.presentation.util
+
+import android.content.Intent
+import android.os.Parcelable
+import androidx.core.content.IntentCompat
+import java.io.Serializable
+
+inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? {
+    return IntentCompat.getParcelableExtra(this, key, T::class.java)
+}
+
+inline fun <reified T: Serializable> Intent.serializable(key: String): T? {
+    return IntentCompat.getSerializableExtra(this, key, T::class.java)
+}

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/IntentExensions.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/IntentExensions.kt
@@ -9,6 +9,6 @@ inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? {
     return IntentCompat.getParcelableExtra(this, key, T::class.java)
 }
 
-inline fun <reified T: Serializable> Intent.serializable(key: String): T? {
+inline fun <reified T : Serializable> Intent.serializable(key: String): T? {
     return IntentCompat.getSerializableExtra(this, key, T::class.java)
 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/fragment/FragmentExtension.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/fragment/FragmentExtension.kt
@@ -1,5 +1,6 @@
 package poke.rogue.helper.presentation.util.fragment
 
+import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.annotation.ColorRes
@@ -62,6 +63,12 @@ fun Fragment.colorOf(
 fun Fragment.drawableOf(
     @DrawableRes resId: Int,
 ) = ContextCompat.getDrawable(requireContext(), resId)
+
+inline fun <T : Fragment> T.withArgs(argsBuilder: Bundle.() -> Unit): T {
+    return this.apply {
+        arguments = Bundle().apply(argsBuilder)
+    }
+}
 
 val Fragment.viewLifeCycle
     get() = viewLifecycleOwner.lifecycle

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/view/CommonBindingAdapter.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/view/CommonBindingAdapter.kt
@@ -2,9 +2,11 @@ package poke.rogue.helper.presentation.util.view
 
 import android.view.View
 import android.widget.ImageView
+import androidx.annotation.ColorRes
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
 import poke.rogue.helper.R
+import poke.rogue.helper.presentation.util.context.colorOf
 
 @BindingAdapter("imageUrl")
 fun ImageView.setImage(imageUrl: String?) {
@@ -18,6 +20,12 @@ fun ImageView.setImage(imageUrl: String?) {
 @BindingAdapter("imageRes")
 fun ImageView.setImageRes(imageRes: Int) {
     setImageResource(imageRes)
+}
+
+@BindingAdapter("backgroundColorRes")
+fun View.setBackGroundColorRes(@ColorRes backgroundColorRes: Int) {
+    if (backgroundColorRes == 0) return
+    setBackgroundColor(context.colorOf(backgroundColorRes))
 }
 
 @BindingAdapter("visible")

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/view/CommonBindingAdapter.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/view/CommonBindingAdapter.kt
@@ -23,7 +23,9 @@ fun ImageView.setImageRes(imageRes: Int) {
 }
 
 @BindingAdapter("backgroundColorRes")
-fun View.setBackGroundColorRes(@ColorRes backgroundColorRes: Int) {
+fun View.setBackGroundColorRes(
+    @ColorRes backgroundColorRes: Int,
+) {
     if (backgroundColorRes == 0) return
     setBackgroundColor(context.colorOf(backgroundColorRes))
 }

--- a/android/app/src/main/res/layout/item_type.xml
+++ b/android/app/src/main/res/layout/item_type.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="type"
+            type="poke.rogue.helper.presentation.type.model.TypeUiModel" />
+
+        <variable
+            name="isEmptyBackground"
+            type="Boolean" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="4dp"
+        app:backgroundColorRes="@{isEmptyBackground ? 0 : type.typeColor}"
+        tools:background="@color/poke_fairy">
+
+        <ImageView
+            android:id="@+id/iv_type_name_icon"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_gravity="center_vertical"
+            app:imageRes="@{type.typeIconResId}"
+            tools:src="@drawable/icon_type_fairy" />
+
+        <Space
+            android:id="@+id/space_type"
+            android:layout_width="8dp"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/tv_type_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{type.typeName}"
+            android:textAppearance="@style/TextAppearance.Poke.CaptionLarge"
+            tools:text="페어리" />
+    </LinearLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_type_name.xml
+++ b/android/app/src/main/res/layout/item_type_name.xml
@@ -9,7 +9,7 @@
             type="poke.rogue.helper.presentation.type.model.TypeUiModel" />
     </data>
 
-    <poke.rogue.helper.presentation.type.view.TypeItemView
+    <poke.rogue.helper.presentation.type.view.TypeChip
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:iconSize="18dp"

--- a/android/app/src/main/res/layout/item_type_name.xml
+++ b/android/app/src/main/res/layout/item_type_name.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -10,31 +9,12 @@
             type="poke.rogue.helper.presentation.type.model.TypeUiModel" />
     </data>
 
-    <LinearLayout
+    <poke.rogue.helper.presentation.type.view.TypeItemView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:paddingHorizontal="8dp"
-        android:paddingVertical="4dp">
-
-        <ImageView
-            android:id="@+id/iv_type_name_icon"
-            imageRes="@{typeItem.typeIconResId}"
-            android:layout_width="18dp"
-            android:layout_height="18dp"
-            android:layout_gravity="center_vertical"
-            android:src="@drawable/img_property_tmp_2" />
-
-        <Space
-            android:layout_width="8dp"
-            android:layout_height="wrap_content" />
-
-        <TextView
-            android:id="@+id/tv_type_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@{typeItem.typeName}"
-            tools:text="페어리" />
-
-    </LinearLayout>
+        app:iconSize="18dp"
+        app:spacing="8dp"
+        app:nameSize="13dp"
+        app:emptyBackGround="true"
+        app:type="@{typeItem}" />
 </layout>

--- a/android/app/src/main/res/values/attrs.xml
+++ b/android/app/src/main/res/values/attrs.xml
@@ -7,4 +7,11 @@
         <attr name="borderColor" format="color" />
         <attr name="borderWidth" format="dimension" />
     </declare-styleable>
+
+    <declare-styleable name="TypeItemView">
+        <attr name="iconSize" format="dimension"/>
+        <attr name="spacing" format="dimension" />
+        <attr name="nameSize" format="dimension" />
+        <attr name="emptyBackGround" format="boolean" />
+    </declare-styleable>
 </resources>

--- a/android/app/src/main/res/values/attrs.xml
+++ b/android/app/src/main/res/values/attrs.xml
@@ -8,7 +8,7 @@
         <attr name="borderWidth" format="dimension" />
     </declare-styleable>
 
-    <declare-styleable name="TypeItemView">
+    <declare-styleable name="TypeChip">
         <attr name="iconSize" format="dimension"/>
         <attr name="spacing" format="dimension" />
         <attr name="nameSize" format="dimension" />

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -10,24 +10,24 @@
     <color name="poke_green_20">#74CC73</color>
     <color name="poke_red_20">#F66868</color>
     <!--    pokemon type-->
-    <color name="poke_grass">#47C50E</color>
-    <color name="poke_electric">#F9DC4A</color>
-    <color name="poke_fighting">#F2A63B</color>
-    <color name="poke_fire">#ED6C3E</color>
-    <color name="poke_flying">#A0C8FA</color>
-    <color name="poke_steel">#7AACCF</color>
-    <color name="poke_ice">#72D5FB</color>
-    <color name="poke_water">#4A90F7</color>
-    <color name="poke_dragon">#5762CF</color>
-    <color name="poke_poison">#8E41D6</color>
-    <color name="poke_ghost">#68476E</color>
-    <color name="poke_ground">#A47B44</color>
-    <color name="poke_psychic">#ED6D81</color>
-    <color name="poke_bug">#A0A43E</color>
-    <color name="poke_rock">#BBB88E</color>
-    <color name="poke_normal">#999999</color>
-    <color name="poke_dark">#4E4747</color>
-    <color name="poke_fairy">#F4B4FA</color>
+    <color name="poke_grass">#459836</color>
+    <color name="poke_electric">#DDBC29</color>
+    <color name="poke_fighting">#E3901E</color>
+    <color name="poke_fire">#E3613F</color>
+    <color name="poke_flying">#75A9D0</color>
+    <color name="poke_steel">#73B1CC</color>
+    <color name="poke_ice">#46C8C8</color>
+    <color name="poke_water">#3199E2</color>
+    <color name="poke_dragon">#576FBE</color>
+    <color name="poke_poison">#9454CC</color>
+    <color name="poke_ghost">#704572</color>
+    <color name="poke_ground">#A4733A</color>
+    <color name="poke_psychic">#E96C8B</color>
+    <color name="poke_bug">#9f9f27</color>
+    <color name="poke_rock">#AAA482</color>
+    <color name="poke_normal">#828282</color>
+    <color name="poke_dark">#514747</color>
+    <color name="poke_fairy">#E08CE0</color>
     <color name="item_pokemon_background_gray">#242627</color>
 
 </resources>

--- a/android/app/src/main/res/values/type.xml
+++ b/android/app/src/main/res/values/type.xml
@@ -39,27 +39,27 @@
     </style>
 
     <style name="TextAppearance.Poke.CaptionLarge">
-        <item name="android:textSize">8sp</item>
-        <item name="lineHeight">12sp</item>
+        <item name="android:textSize">13sp</item>
+        <item name="lineHeight">18.5sp</item>
     </style>
 
     <style name="TextAppearance.Poke.CaptionLargeBold">
         <item name="android:textStyle">bold</item>
         <item name="font">@font/pretendard_semibold</item>
-        <item name="android:textSize">8sp</item>
-        <item name="lineHeight">12sp</item>
+        <item name="android:textSize">13sp</item>
+        <item name="lineHeight">18.5sp</item>
     </style>
 
     <style name="TextAppearance.Poke.Caption">
-        <item name="android:textSize">7sp</item>
-        <item name="lineHeight">10.5sp</item>
+        <item name="android:textSize">11sp</item>
+        <item name="lineHeight">16.5sp</item>
     </style>
 
     <style name="TextAppearance.Poke.CaptionBold">
         <item name="android:textStyle">bold</item>
         <item name="font">@font/pretendard_semibold</item>
-        <item name="android:textSize">7sp</item>
-        <item name="lineHeight">10.5sp</item>
+        <item name="android:textSize">11sp</item>
+        <item name="lineHeight">16.5sp</item>
     </style>
 
 </resources>


### PR DESCRIPTION
- closed #35 
## 작업 화면

`TypeChip` Component 입니다. attrs 값을 조절하여 TypeChip 의 크기를 조정할 수 있습니다

- `app:iconSize="40dp"` : IconSIze

<image width = "500" src="https://github.com/user-attachments/assets/c23f500a-2864-4aa7-a70b-ee03a7cd2eb0"/>

- `app:emptyBackGround="false"` : 뒷배경이 없을 때

<image width = "500"  src="https://github.com/user-attachments/assets/ba822b9c-0261-4dbb-a27a-e8ed707a36ec"/>


## 작업한 내용

- [x] PokeTypeChip 구현
- [x] BindingAdapter 추가 - BackgroundColorRes
- [x] BundleExtension, IntentExtension
- [x] TypeItemView CustomVIew 구현
- [x] withArgs Fragment 확장함수 구현
- [x] 변경된 TextAppearance 수정 

## PR 포인트
- 여러가지 util 함수들을 몇개 추가했습니다. 보고 이해 안되시면 코멘트 남겨주세요!

`seriablizable`, `parcelable`, `withArgs`, 

## 🚀Next Feature

이제 전 배포 및 모니터링 툴 다는걸 준비할게요!
