### PR TITLE
[BE-FEAT] Nginx keepalive, log 설정 변경

### DIFF
--- a/.github/workflows/Backend-CD.yml
+++ b/.github/workflows/Backend-CD.yml
@@ -51,6 +51,8 @@ jobs:
         run: |
           cd /home/ubuntu
           
+          sudo mkdir -p log/nginx && sudo touch log/nginx/error.log && sudo touch log/nginx/access.log
+          
           sudo touch docker-compose.yml
           echo "${{ vars.DOCKER_COMPOSE }}" | sudo tee docker-compose.yml > /dev/null
           

--- a/.github/workflows/Backend-CD.yml
+++ b/.github/workflows/Backend-CD.yml
@@ -2,7 +2,7 @@ name: Backend CD
 
 on:
   push:
-    branches: [ "be/develop" ]
+    branches: [ "be/feat/#79-fix-nginx-config" ]
 
 permissions:
   contents: read

--- a/.github/workflows/Backend-CD.yml
+++ b/.github/workflows/Backend-CD.yml
@@ -2,7 +2,7 @@ name: Backend CD
 
 on:
   push:
-    branches: [ "be/feat/#79-fix-nginx-config" ]
+    branches: [ "be/develop" ]
 
 permissions:
   contents: read

--- a/backend/pokerogue/docker/nginx/conf.d/nginx.conf
+++ b/backend/pokerogue/docker/nginx/conf.d/nginx.conf
@@ -4,8 +4,8 @@ upstream was {
 }
 
 server {
-        server_name _;
-        listen 80 default_server;
+        server_name pokerogue-helper.com;
+        listen 80 ;
 
         location / {
                 resolver 8.8.8.8 ipv6=off;
@@ -38,14 +38,4 @@ server {
         ssl_certificate_key /etc/letsencrypt/live/pokerogue-helper.com/privkey.pem;
         include /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-}
-
-server {
-        server_name pokerogue-helper.com;
-        listen 80 ;
-
-        if ($host = pokerogue-helper.com) {
-            return 301 https://$host$request_uri;
-        }
-        return 404;
 }

--- a/backend/pokerogue/docker/nginx/conf.d/nginx.conf
+++ b/backend/pokerogue/docker/nginx/conf.d/nginx.conf
@@ -1,3 +1,6 @@
+access_log /log/nginx/access.log;
+error_log /log/nginx/error.log;
+
 upstream was {
     server server:8080;
     keepalive 32;

--- a/backend/pokerogue/docker/nginx/conf.d/nginx.conf
+++ b/backend/pokerogue/docker/nginx/conf.d/nginx.conf
@@ -4,8 +4,8 @@ upstream was {
 }
 
 server {
-        server_name pokerogue-helper.com;
-        listen 80 ;
+        server_name _;
+        listen 80 default_server;
 
         location / {
                 resolver 8.8.8.8 ipv6=off;
@@ -38,4 +38,14 @@ server {
         ssl_certificate_key /etc/letsencrypt/live/pokerogue-helper.com/privkey.pem;
         include /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+        server_name pokerogue-helper.com;
+        listen 80 ;
+
+        if ($host = pokerogue-helper.com) {
+            return 301 https://$host$request_uri;
+        }
+        return 404;
 }

--- a/backend/pokerogue/docker/nginx/conf.d/nginx.conf
+++ b/backend/pokerogue/docker/nginx/conf.d/nginx.conf
@@ -1,31 +1,39 @@
+upstream was {
+    server server:8080;
+    keepalive 32;
+}
+
 server {
-        listen [::]:80 default_server;
-        root /var/www/html;
         server_name _;
+        listen 80 default_server;
 
         location / {
                 resolver 8.8.8.8 ipv6=off;
-                proxy_pass http://server:8080;
+                proxy_pass http://was;
                 proxy_set_header X-Real_IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header Host $http_host;
+
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
         }
 }
 
 server {
-        root /var/www/html;
         server_name pokerogue-helper.com;
+        listen 443 ssl;
 
         location / {
-                resolver 8.8.8.8;
-                proxy_pass http://server:8080;
+                resolver 8.8.8.8 ipv6=off;
+                proxy_pass http://was;
                 proxy_set_header X-Real_IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header Host $http_host;
+
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
         }
 
-        listen [::]:443 ssl;
-        listen 443 ssl;
         ssl_certificate /etc/letsencrypt/live/pokerogue-helper.com/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/pokerogue-helper.com/privkey.pem;
         include /etc/letsencrypt/options-ssl-nginx.conf;
@@ -33,12 +41,11 @@ server {
 }
 
 server {
+        server_name pokerogue-helper.com;
+        listen 80 ;
+
         if ($host = pokerogue-helper.com) {
             return 301 https://$host$request_uri;
         }
-
-        listen 80 ;
-        listen [::]:80 ;
-        server_name pokerogue-helper.com;
         return 404;
 }


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [ ] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #79

- [x] Keep-alive 설정 추가
- [x] access, error log 설정 추가

저번 설정 파일에서 잘못되었던 부분
```bash
# nginx.conf
upstream was {
    server http://server:8080;
    keepalive 32;
}
```

고친 후 🥲
```bash
upstream was {
    server server:8080;
    keepalive 32;
}
```

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [ ] 있음
- [x] 없음
