### PR TITLE
[BE-INFRA] 무작위 네트워크 공격 방지를 위한 fail2ban 추가

### DIFF
--- a/.github/workflows/Backend-CD.yml
+++ b/.github/workflows/Backend-CD.yml
@@ -2,7 +2,7 @@ name: Backend CD
 
 on:
   push:
-    branches: [ "be/develop" ]
+    branches: [ "be/refactor/fail2ban" ]
 
 permissions:
   contents: read
@@ -37,7 +37,12 @@ jobs:
           
           docker build -t ${{ secrets.DOCKER_NGINX_IMAGE }} -f ./backend/pokerogue/docker/Dockerfile-nginx ./backend/pokerogue/docker
           docker push ${{ secrets.DOCKER_NGINX_IMAGE }}
+          
+          docker build -t ${{ secrets.DOCKER_FAIL2BAN_IMAGE }} -f ./backend/pokerogue/docker/Dockerfile-fail2ban ./backend/pokerogue/docker
+          docker push ${{ secrets.DOCKER_FAILE2BAN_IMAGE }}
 
+  
+  
   deploy:
     needs: build
     runs-on: self-hosted
@@ -66,6 +71,7 @@ jobs:
           
           sudo docker pull ${{ secrets.DOCKER_SERVER_IMAGE }}
           sudo docker pull ${{ secrets.DOCKER_NGINX_IMAGE }}
+          sudo docker pull ${{ secrets.DOCKER_FAIL2BAN_IMAGE }}
           
           docker-compose -f docker-compose.yml up -d
           docker image prune -f

--- a/.github/workflows/Backend-CD.yml
+++ b/.github/workflows/Backend-CD.yml
@@ -39,7 +39,7 @@ jobs:
           docker push ${{ secrets.DOCKER_NGINX_IMAGE }}
           
           docker build -t ${{ secrets.DOCKER_FAIL2BAN_IMAGE }} -f ./backend/pokerogue/docker/Dockerfile-fail2ban ./backend/pokerogue/docker
-          docker push ${{ secrets.DOCKER_FAILE2BAN_IMAGE }}
+          docker push ${{ secrets.DOCKER_FAIL2BAN_IMAGE }}
 
   
   

--- a/.github/workflows/Backend-CD.yml
+++ b/.github/workflows/Backend-CD.yml
@@ -2,7 +2,7 @@ name: Backend CD
 
 on:
   push:
-    branches: [ "be/refactor/fail2ban" ]
+    branches: [ "be/develop" ]
 
 permissions:
   contents: read

--- a/backend/pokerogue/docker/Dockerfile-fail2ban
+++ b/backend/pokerogue/docker/Dockerfile-fail2ban
@@ -1,0 +1,4 @@
+FROM crazymax/fail2ban
+RUN rm -rf /etc/fail2ban/paths-common.conf
+COPY ./fail2ban/jail.local /etc/fail2ban
+COPY ./fail2ban/paths-common.conf /etc/fail2ban

--- a/backend/pokerogue/docker/Dockerfile-nginx
+++ b/backend/pokerogue/docker/Dockerfile-nginx
@@ -1,4 +1,6 @@
 FROM nginx
 RUN rm -rf /etc/nginx/conf.d/default.conf
+RUN rm -rf /etc/nginx/nginx.conf
 COPY ./nginx/conf.d/nginx.conf /etc/nginx/conf.d
+COPY ./nginx/nginx.conf /etc/nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/backend/pokerogue/docker/fail2ban/jail.local
+++ b/backend/pokerogue/docker/fail2ban/jail.local
@@ -1,0 +1,5 @@
+[nginx-limit-req]
+enabled=true
+chain=DOCKER-USER
+port=http,https
+bantime=-1

--- a/backend/pokerogue/docker/fail2ban/paths-common.conf
+++ b/backend/pokerogue/docker/fail2ban/paths-common.conf
@@ -1,0 +1,93 @@
+# Common
+#
+
+[INCLUDES]
+
+after  = paths-overrides.local
+
+[DEFAULT]
+
+default_backend = %(default/backend)s
+
+# Initial common values (to overwrite in path-<distribution>.conf)...
+# There is no sensible generic defaults for syslog log targets, thus
+# leaving them empty here (resp. set to mostly used variant) in order
+# to avoid errors while parsing/interpolating configs.
+#
+# Note systemd-backend does not need the logpath at all.
+#
+syslog_local0 = /var/log/messages
+
+syslog_authpriv = /var/log/auth.log
+syslog_daemon  = %(syslog_local0)s
+syslog_ftp = %(syslog_local0)s
+syslog_mail =
+syslog_mail_warn =
+syslog_user = %(syslog_local0)s
+
+# Set the default syslog backend target to default_backend
+syslog_backend = %(default_backend)s
+
+# Default values for several jails:
+
+sshd_log = %(syslog_authpriv)s
+sshd_backend = %(default_backend)s
+
+dropbear_log = %(syslog_authpriv)s
+dropbear_backend = %(default_backend)s
+
+apache_error_log = /var/log/apache2/*error.log
+
+apache_access_log = /var/log/apache2/*access.log
+
+# from /etc/audit/auditd.conf
+auditd_log = /var/log/audit/audit.log
+
+exim_main_log = /var/log/exim/mainlog
+
+nginx_error_log = /log/nginx/*error.log
+
+nginx_access_log = /log/nginx/*access.log
+
+
+lighttpd_error_log = /var/log/lighttpd/error.log
+
+# http://www.hardened-php.net/suhosin/configuration.html#suhosin.log.syslog.facility
+# syslog_user is the default. Lighttpd also hooks errors into its log.
+
+suhosin_log = %(syslog_user)s
+              %(lighttpd_error_log)s
+
+# defaults to ftp or local2 if ftp doesn't exist
+proftpd_log = %(syslog_ftp)s
+proftpd_backend = %(default_backend)s
+
+# http://svnweb.freebsd.org/ports/head/ftp/proftpd/files/patch-src_proftpd.8.in?view=markup
+# defaults to ftp but can be overwritten.
+pureftpd_log = %(syslog_ftp)s
+pureftpd_backend = %(default_backend)s
+
+# ftp, daemon and then local7 are tried at configure time however it is overwritable at configure time
+#
+wuftpd_log = %(syslog_ftp)s
+wuftpd_backend = %(default_backend)s
+
+# syslog_enable defaults to no. so it defaults to vsftpd_log_file setting of /var/log/vsftpd.log
+# No distro seems to set it to syslog by default
+# If syslog set it defaults to ftp facility if exists at compile time otherwise falls back to daemonlog.
+vsftpd_log = /var/log/vsftpd.log
+
+# Technically syslog_facility in main.cf can overwrite but no-one sane does this.
+postfix_log = %(syslog_mail_warn)s
+postfix_backend = %(default_backend)s
+
+dovecot_log = %(syslog_mail_warn)s
+dovecot_backend = %(default_backend)s
+
+# Seems to be set at compile time only to LOG_LOCAL0 (src/const.h) at Notice level
+solidpop3d_log = %(syslog_local0)s
+
+mysql_log = %(syslog_daemon)s
+mysql_backend = %(default_backend)s
+
+roundcube_errors_log = /var/log/roundcube/errors

--- a/backend/pokerogue/docker/nginx/conf.d/nginx.conf
+++ b/backend/pokerogue/docker/nginx/conf.d/nginx.conf
@@ -12,11 +12,14 @@ server {
 
         location / {
                 resolver 8.8.8.8 ipv6=off;
+
+				limit_req zone=my_limit;
+				limit_req_status 429;
+
                 proxy_pass http://was;
                 proxy_set_header X-Real_IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header Host $http_host;
-
                 proxy_http_version 1.1;
                 proxy_set_header Connection "";
         }
@@ -28,11 +31,14 @@ server {
 
         location / {
                 resolver 8.8.8.8 ipv6=off;
+
+				limit_req zone=my_limit;
+				limit_req_status 429;
+
                 proxy_pass http://was;
                 proxy_set_header X-Real_IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header Host $http_host;
-
                 proxy_http_version 1.1;
                 proxy_set_header Connection "";
         }

--- a/backend/pokerogue/docker/nginx/nginx.conf
+++ b/backend/pokerogue/docker/nginx/nginx.conf
@@ -1,0 +1,33 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+	include       /etc/nginx/mime.types;
+	default_type  application/octet-stream;
+
+	limit_req_zone $binary_remote_addr zone=my_limit:10m rate=1r/s;
+
+	log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+					  '$status $body_bytes_sent "$http_referer" '
+					  '"$http_user_agent" "$http_x_forwarded_for"';
+
+	access_log  /var/log/nginx/access.log  main;
+
+	sendfile        on;
+	#tcp_nopush     on;
+
+	keepalive_timeout  65;
+
+	#gzip  on;
+
+	include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [ ] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #115 

- [x] 동일한 IP의 반복적인 요청을 `nginx`의 `limit_req` 모듈을 통해 제한한다.
- [x] `fail2ban` 도커 컨테이너를 생성하는 스크립트를 작성한다.
- [x] 일정 시간 내에 반복적인 요청이 과다하면 `fail2ban`을 통해 차단한다.

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [ ] 있음
- [x] 없음



---
## fail2ban이 궁금하시다면 읽어보세요!

`fail2ban`은 로그 텍스트 파일을 분석하여 `iptables`을 이용하여 네트워크 요청에 대한 필터링을 할 수 있도록 돕습니다.
`iptables`는 리눅스나 우분투에서 사용되는 유틸리티 프로그램입니다.
`iptables`를 사용하면 리눅스 커널의 방화벽 설정을 편하게 커스터마이징할 수 있습니다.

방화벽이란 결국 네트워크 패킷을 필터링하는 것이고, 심지어 패킷의 형태를 바꿀 수도 있고, 포트 매핑도 가능합니다.

도커에서 컨테이너를 사용할 때 호스트와 포트 매핑을 하는 경우가 많습니다. 
도커 역시 세부적으로는 `iptables`를 사용하고 있습니다.

`fail2ban`은 `iptables`를 조금 더 사용하기 쉽게 도와줍니다.

도커를 사용하는 저희 환경에서 `nginx`의 로그파일을 호스트 환경에 마운트 시키...