### PR TITLE
[BE-INFRA] 쿼리 테스트 환경 구성

### DIFF
--- a/backend/pokerogue/src/test/java/com/pokerogue/environment/repository/RepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/environment/repository/RepositoryTest.java
@@ -5,7 +5,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
-@ActiveProfiles("local-mysql")
+@ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class RepositoryTest {
 }


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [ ] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #127

- [x] 조회용 도커 이미지 생성 ( `== 모든 포켓몬 데이터가 있는 DB`)
- [x] ⚠️ 조회용 DB의 mysql user는 수정 권한을 갖지 않는다 (데이터 날아가는 실수 방지!)
- [x] docker compose 파일 작성 및 공유

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [x] 있음
- [ ] 없음

### ✨ h2 db를 사용하던 yml을 삭제하고, 조회용 테스트 db를 연결하고 있는 `application-test.yml`을 추가했습니다. 
아래와 같은 상황에서 쓰면 좋을 것 같습니다.
1) JPA 쿼리메소드(쿼리) 테스트
2) (조회) API 부하 테스트
3) AN이 `localhost`에서 사용할 테스트 환경

⚠️ 모든 팀원이 공유하는 테스트 db이기 때문에 데이터나 테이블 수정(`insert`, `delete`, `create table`, `truncate`)이 안됩니다. 설정 파일에 나와 있는 MySQL 유저로만 사용해주세요 !
⚠️ `RepositoryTest`만 profile을 `test`로 지정해놓았고, 나머지는 `local-mysql`로 두었습니다.

### ✨  `application-test.yml` 사용하는 법
1) 노션의 Test DB 페이지에서 docker-compose.yml을 다운 받고 실행시킨다.
2) yml 파일을 test로 지정해서 테스트하거나 로컬 서버를 올린다. (테스트 코드는 `@ActiveProfiles` 사용)