### PR TITLE
[BE-REFACTOR] PokemonAbility 쿼리 개선

### DIFF
--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/domain/PokemonAbility.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/domain/PokemonAbility.java
@@ -9,7 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,7 +37,7 @@ public class PokemonAbility {
     private String detailDescription;
 
     @OneToMany(mappedBy = "pokemonAbility", fetch = FetchType.LAZY)
-    private List<PokemonAbilityMapping> pokemonAbilityMappings;
+    private Set<PokemonAbilityMapping> pokemonAbilityMappings;
 
     public PokemonAbility(String name, String koName, String description, String detailDescription) {
         this.name = name;

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepository.java
@@ -11,12 +11,12 @@ public interface PokemonAbilityRepository extends JpaRepository<PokemonAbility, 
 
     @NonNull
     @Query("""
-            select a from PokemonAbility a
-            join fetch a.pokemonAbilityMappings m
-            join fetch m.pokemon p
-            join fetch p.pokemonTypeMappings pt
-            join fetch pt.pokemonType t
-            where a.id = :id
+            select pa from PokemonAbility pa
+            join fetch pa.pokemonAbilityMappings pam
+            join fetch pam.pokemon p
+            join fetch p.pokemonTypeMappings ptm
+            join fetch ptm.pokemonType pt
+            where pa.id = :id
             """)
     Optional<PokemonAbility> findByIdWithPokemonAndPokemonTypes(@NonNull @Param("id") Long id);
 

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepository.java
@@ -18,7 +18,7 @@ public interface PokemonAbilityRepository extends JpaRepository<PokemonAbility, 
             join fetch pt.pokemonType t
             where a.id = :id
             """)
-    Optional<PokemonAbility> findByIdWithPokemonMappings(@NonNull @Param("id") Long id);
+    Optional<PokemonAbility> findByIdWithPokemonAndPokemonTypes(@NonNull @Param("id") Long id);
 
     Optional<PokemonAbility> findByName(String name);
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepository.java
@@ -1,9 +1,7 @@
 package com.pokerogue.helper.ability.repository;
 
 import com.pokerogue.helper.ability.domain.PokemonAbility;
-
 import io.micrometer.common.lang.NonNull;
-
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,11 +9,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface PokemonAbilityRepository extends JpaRepository<PokemonAbility, Long> {
 
-
     @NonNull
     @Query("""
             select a from PokemonAbility a
             join fetch a.pokemonAbilityMappings m
+            join fetch m.pokemon p
+            join fetch p.pokemonTypeMappings pt
+            join fetch pt.pokemonType t
             where a.id = :id
             """)
     Optional<PokemonAbility> findByIdWithPokemonMappings(@NonNull @Param("id") Long id);

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
@@ -59,7 +59,7 @@ public class PokemonAbilityService {
                         pokemon -> pokemon,
                         pokemon -> pokemon.getPokemonTypeMappings().stream()
                                 .map(PokemonTypeMapping::getPokemonType)
-                                .collect(Collectors.toList())
+                                .toList()
                 ));
     }
 

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
@@ -33,7 +33,7 @@ public class PokemonAbilityService {
     }
 
     public PokemonAbilityWithPokemonsResponse findAbilityDetails(Long id) {
-        PokemonAbility ability = pokemonAbilityRepository.findByIdWithPokemonMappings(id)
+        PokemonAbility ability = pokemonAbilityRepository.findByIdWithPokemonAndPokemonTypes(id)
                 .orElseThrow(() -> new GlobalCustomException(ErrorMessage.POKEMON_ABILITY_NOT_FOUND));
 
         List<Pokemon> pokemons = ability.getPokemonAbilityMappings().stream()

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.pokerogue.helper.ability.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.pokerogue.helper.ability.domain.PokemonAbility;
+import com.pokerogue.helper.environ.repository.RepositoryTest;
+import com.pokerogue.helper.pokemon.domain.Pokemon;
+import com.pokerogue.helper.pokemon.domain.PokemonAbilityMapping;
+import com.pokerogue.helper.pokemon.domain.PokemonTypeMapping;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PokemonAbilityRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private PokemonAbilityRepository pokemonAbilityRepository;
+
+    @Test
+    @DisplayName("특성에 해당하는 포켓몬과 포켓몬 타입들을 조회한다.")
+    void findByIdWithPokemonAndPokemonTypes() {
+        PokemonAbility pokemonAbility = pokemonAbilityRepository.findAll().get(0);
+        Long pokemonAbilityId = pokemonAbility.getId();
+
+        PokemonAbility queriedPokemon = pokemonAbilityRepository.findByIdWithPokemonAndPokemonTypes(pokemonAbilityId)
+                .get();
+        Set<PokemonAbilityMapping> pokemonAbilityMappings = queriedPokemon.getPokemonAbilityMappings();
+        List<Pokemon> pokemons = pokemonAbilityMappings.stream()
+                .map(PokemonAbilityMapping::getPokemon)
+                .toList();
+
+        assertAll(
+                () -> assertThat(pokemons).isNotEmpty(),
+                () -> assertThat(pokemons.stream()
+                        .flatMap(pokemon -> pokemon.getPokemonTypeMappings().stream()
+                                .map(PokemonTypeMapping::getPokemonType))
+                        .toList()).isNotEmpty()
+        );
+    }
+}

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/service/PokemonAbilityServiceTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/service/PokemonAbilityServiceTest.java
@@ -1,0 +1,24 @@
+package com.pokerogue.helper.ability.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.pokerogue.helper.environ.service.ServiceTest;
+import com.pokerogue.helper.global.exception.ErrorMessage;
+import com.pokerogue.helper.global.exception.GlobalCustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PokemonAbilityServiceTest extends ServiceTest {
+
+    @Autowired
+    private PokemonAbilityService pokemonAbilityService;
+
+    @Test
+    @DisplayName("존재하지 않는 포켓몬의 특성을 조회하면 예외가 발생한다.")
+    void findAbilityDetailsWhenAbilityIdNotExist() {
+        assertThatThrownBy(() -> pokemonAbilityService.findAbilityDetails(Long.MAX_VALUE))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.POKEMON_ABILITY_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [x] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #125 

- [x] `findAll`의 쿼리를 확인하고 개선한다.
- [x] `findByIdWithPokemonMappings` 의 쿼리를 확인하고 개선한다.
- [x] 각 개선 사항의 통계치를 만들어둔다.

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [x] 있음
- [ ] 없음

```
`findByIdWithPokemonMappings`를 `fetch Join` 하여 포켓몬 당 한번의 쿼리가 아닌,
해당 `ability`에 해당하는 값들을 전부 영속성 컨텍스트에 저장하도록 수정
```

### 통계

![KakaoTalk_Photo_2024-08-02-17-49-47](https://github.com/user-attachments/assets/c07342f1-8068-4cea-9f39-0da14c03cfb3)
![KakaoTalk_Photo_2024-08-02-17-49-52](https://github.com/user-attachments/assets/384f76d1-6647-41a6-86a6-250a71df02df)

유저가 1000명, 5번씩 동시에 요청하는 경우 (해당 `ability`에 해당하는 포켓몬이 49마리)
인 경우 약 7배의 차이가 생김