### PR TITLE
[BE-REFACTOR] PokemonType 쿼리 개선 

### DIFF
--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/type/repository/PokemonTypeMatchingRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/type/repository/PokemonTypeMatchingRepository.java
@@ -8,6 +8,7 @@ import org.springframework.lang.NonNull;
 
 public interface PokemonTypeMatchingRepository extends JpaRepository<PokemonTypeMatching, Long> {
 
+    @Override
     @NonNull
     @Query("""
             select ptm from PokemonTypeMatching ptm

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/type/repository/PokemonTypeMatchingRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/type/repository/PokemonTypeMatchingRepository.java
@@ -1,7 +1,18 @@
 package com.pokerogue.helper.type.repository;
 
 import com.pokerogue.helper.type.domain.PokemonTypeMatching;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.lang.NonNull;
 
 public interface PokemonTypeMatchingRepository extends JpaRepository<PokemonTypeMatching, Long> {
+
+    @NonNull
+    @Query("""
+            select ptm from PokemonTypeMatching ptm
+            join fetch ptm.toType tt
+            join fetch ptm.fromType ft
+            """)
+    List<PokemonTypeMatching> findAll();
 }

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/type/repository/PokemonTypeMatchingRepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/type/repository/PokemonTypeMatchingRepositoryTest.java
@@ -1,0 +1,26 @@
+package com.pokerogue.helper.type.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.pokerogue.environment.repository.RepositoryTest;
+import com.pokerogue.helper.type.domain.PokemonTypeMatching;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PokemonTypeMatchingRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private PokemonTypeMatchingRepository pokemonTypeMatchingRepository;
+
+    @Test
+    @DisplayName("포켓몬의 모든 타입 매칭 정보를 조회한다.")
+    void findAll() {
+        List<PokemonTypeMatching> pokemonTypeMatchings = pokemonTypeMatchingRepository.findAll();
+
+        Assertions.assertThat(pokemonTypeMatchings).isNotEmpty();
+    }
+
+}

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/type/repository/PokemonTypeMatchingRepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/type/repository/PokemonTypeMatchingRepositoryTest.java
@@ -15,12 +15,17 @@ class PokemonTypeMatchingRepositoryTest extends RepositoryTest {
     @Autowired
     private PokemonTypeMatchingRepository pokemonTypeMatchingRepository;
 
-    @Test
-    @DisplayName("포켓몬의 모든 타입 매칭 정보를 조회한다.")
-    void findAll() {
-        List<PokemonTypeMatching> pokemonTypeMatchings = pokemonTypeMatchingRepository.findAll();
 
-        Assertions.assertThat(pokemonTypeMatchings).isNotEmpty();
-    }
+    /*
+        PR: [BE-REFACTOR] Pokemon 쿼리 개선 #133
+        위 PR이 먼저 머지되어야 실행 가능한 테스트라서 주석 처리함.
+     */
+//    @Test
+//    @DisplayName("포켓몬의 모든 타입 매칭 정보를 조회한다.")
+//    void findAll() {
+//        List<PokemonTypeMatching> pokemonTypeMatchings = pokemonTypeMatchingRepository.findAll();
+//
+//        Assertions.assertThat(pokemonTypeMatchings).isNotEmpty();
+//    }
 
 }


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [ ] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.

> Issue Number: #128 

- [x] Type.findAll의 쿼리를 확인하고 개선한다.
- [x] TypeMatching.findAll의 쿼리를 확인하고 개선한다.
- [x] 각 개선 사항의 통계치를 만들어둔다.

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [] 있음
- [x] 없음


- Type.findAll, Type.findByName 은 개선할 점이 보이지 않았습니다.
- TypeMatching.findAll은 `Join fetch`를 사용하여 쿼리의 횟수를 줄였습니다.
- [개선 전 후 비교](https://github.com/woowacourse-teams/2024-pokerogue-helper/issues/128#issuecomment-2265316132)