### PR TITLE
[AN-Config] 테스트용 디바이스 추가

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -63,6 +63,62 @@ android {
     }
     testOptions {
         animationsDisabled = true
+        managedDevices {
+            localDevices {
+                create("pixel4api27") {
+                    device = "Pixel 4"
+                    apiLevel = 27
+                    systemImageSource = "aosp"
+                }
+                create("pixel4api28") {
+                    device = "Pixel 4"
+                    apiLevel = 28
+                    systemImageSource = "aosp"
+                }
+                create("pixel4api29") {
+                    device = "Pixel 4"
+                    apiLevel = 29
+                    systemImageSource = "aosp"
+                }
+                create("pixel4api30") {
+                    device = "Pixel 4"
+                    apiLevel = 30
+                    systemImageSource = "aosp"
+                }
+                create("pixel4api31") {
+                    device = "Pixel 4"
+                    apiLevel = 31
+                    systemImageSource = "aosp"
+                }
+                create("pixel4api32") {
+                    device = "Pixel 4"
+                    apiLevel = 32
+                    systemImageSource = "aosp"
+                }
+                create("pixel4api33") {
+                    device = "Pixel 4"
+                    apiLevel = 33
+                    systemImageSource = "aosp"
+                }
+                create("pixel4api34") {
+                    device = "Pixel 4"
+                    apiLevel = 34
+                    systemImageSource = "aosp"
+                }
+            }
+            groups {
+                create("phones") {
+                    targetDevices.add(devices["pixel4api27"])
+                    targetDevices.add(devices["pixel4api28"])
+                    targetDevices.add(devices["pixel4api29"])
+                    targetDevices.add(devices["pixel4api30"])
+                    targetDevices.add(devices["pixel4api31"])
+                    targetDevices.add(devices["pixel4api32"])
+                    targetDevices.add(devices["pixel4api33"])
+                    targetDevices.add(devices["pixel4api34"])
+                }
+            }
+        }
     }
 }
 

--- a/android/stringmatcher/build.gradle.kts
+++ b/android/stringmatcher/build.gradle.kts
@@ -7,3 +7,9 @@ dependencies {
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.kotlin.test)
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}


### PR DESCRIPTION
- closed #147 
## 작업 영상

## 작업한 내용
- api 27~34까지 추가하였습니다.

## PR 포인트
- API levels 27 and higher 이상부터 추가할 수 있어서 27부터 34까지 추가했습니다.
- 사용법은 `./gradlew pixel4api30DebugAndroidTest`로 `device-name`과`BuildVariant`를 넣어주시면 됩니다.
- 한번에 모든 기기를 사용하고 싶으면 group name인 phones를 넣으시면 적용됩니다 !

## 🚀Next Feature
