### PR TITLE
[BE-FIX] 포켓몬 목록 조회 정렬 적용

### DIFF
--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
@@ -12,6 +12,8 @@ import com.pokerogue.helper.pokemon.domain.PokemonAbilityMapping;
 import com.pokerogue.helper.pokemon.domain.PokemonTypeMapping;
 import com.pokerogue.helper.type.domain.PokemonType;
 import com.pokerogue.helper.type.dto.PokemonTypeResponse;
+
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -38,9 +40,9 @@ public class PokemonAbilityService {
 
         List<Pokemon> pokemons = ability.getPokemonAbilityMappings().stream()
                 .map(PokemonAbilityMapping::getPokemon)
+                .sorted(Comparator.comparingLong(Pokemon::getId))
                 .toList();
-        List<SameAbilityPokemonResponse> pokemonResponses = toSameAbilityPokemonResponses(
-                pokemons);
+        List<SameAbilityPokemonResponse> pokemonResponses = toSameAbilityPokemonResponses(pokemons);
 
         return new PokemonAbilityWithPokemonsResponse(ability.getKoName(), ability.getDescription(), pokemonResponses);
     }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/repository/PokemonRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/repository/PokemonRepository.java
@@ -23,6 +23,7 @@ public interface PokemonRepository extends JpaRepository<Pokemon, Long> {
             select p from Pokemon p
             join fetch p.pokemonTypeMappings ptm
             join fetch ptm.pokemonType
+            order by p.id
             """)
     List<Pokemon> findAllWithTypes();
 }

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/service/PokemonAbilityServiceTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/service/PokemonAbilityServiceTest.java
@@ -1,18 +1,27 @@
 package com.pokerogue.helper.ability.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.pokerogue.environment.service.ServiceTest;
+import com.pokerogue.helper.ability.dto.PokemonAbilityWithPokemonsResponse;
+import com.pokerogue.helper.ability.dto.SameAbilityPokemonResponse;
+import com.pokerogue.helper.ability.repository.PokemonAbilityRepository;
 import com.pokerogue.helper.global.exception.ErrorMessage;
 import com.pokerogue.helper.global.exception.GlobalCustomException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 class PokemonAbilityServiceTest extends ServiceTest {
 
     @Autowired
     private PokemonAbilityService pokemonAbilityService;
+
+    @Autowired
+    private PokemonAbilityRepository pokemonAbilityRepository;
 
     @Test
     @DisplayName("존재하지 않는 포켓몬의 특성을 조회하면 예외가 발생한다.")
@@ -20,5 +29,18 @@ class PokemonAbilityServiceTest extends ServiceTest {
         assertThatThrownBy(() -> pokemonAbilityService.findAbilityDetails(Long.MAX_VALUE))
                 .isInstanceOf(GlobalCustomException.class)
                 .hasMessage(ErrorMessage.POKEMON_ABILITY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("같은 특성을 가진 포켓몬 목록을 조회할 때 id 순으로 정렬한다.")
+    void findPokemonsOrderByIdInAbilityDetails() {
+        Long abilityId = pokemonAbilityRepository.findAll().get(0).getId();
+
+        PokemonAbilityWithPokemonsResponse pokemonAbilityWithPokemons = pokemonAbilityService.findAbilityDetails(abilityId);
+
+        List<Long> pokemonIds = pokemonAbilityWithPokemons.pokemons().stream()
+                .map(SameAbilityPokemonResponse::id)
+                .toList();
+        assertThat(pokemonIds).isSortedAccordingTo(Long::compare);
     }
 }

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/pokemon/repository/PokemonRepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/pokemon/repository/PokemonRepositoryTest.java
@@ -40,6 +40,17 @@ class PokemonRepositoryTest extends RepositoryTest {
     }
 
     @Test
+    @DisplayName("모든 포켓몬을 id 순으로 조회한다.")
+    void findAllWithTypesOrderById() {
+        List<Pokemon> pokemons = pokemonRepository.findAllWithTypes();
+
+        List<Long> pokemonIds = pokemons.stream()
+                .map(Pokemon::getId)
+                .toList();
+        assertThat(pokemonIds).isSortedAccordingTo(Long::compare);
+    }
+
+    @Test
     @DisplayName("id로 포켓몬 상세 정보를 타입, 특성 정보와 함께 조회한다.")
     void findDetailsById() {
         Pokemon pokemon = pokemonRepository.findAllWithTypes().get(0);


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [ ] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #155

- [x] 포켓몬 도감 페이지: id로 포켓몬 목록 정렬
- [x] 특성 상세 페이지: id로 포켓몬 목록 정렬

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [x] 있음
- [ ] 없음

- 포켓몬 도감 페이지 정렬은 쿼리로, 특성 상세 페이지 정렬은 서비스 코드로 진행했습니다 :)