### PR TITLE
[BE-FIX] 포켓몬이 없는 특성 상세 페이지 조회, 포켓몬 타입 정렬

### DIFF
--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepository.java
@@ -12,10 +12,10 @@ public interface PokemonAbilityRepository extends JpaRepository<PokemonAbility, 
     @NonNull
     @Query("""
             select pa from PokemonAbility pa
-            join fetch pa.pokemonAbilityMappings pam
-            join fetch pam.pokemon p
-            join fetch p.pokemonTypeMappings ptm
-            join fetch ptm.pokemonType pt
+            left join fetch pa.pokemonAbilityMappings pam
+            left join fetch pam.pokemon p
+            left join fetch p.pokemonTypeMappings ptm
+            left join fetch ptm.pokemonType pt
             where pa.id = :id
             """)
     Optional<PokemonAbility> findByIdWithPokemonAndPokemonTypes(@NonNull @Param("id") Long id);

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
@@ -63,6 +63,7 @@ public class PokemonAbilityService {
                         pokemon -> pokemon,
                         pokemon -> pokemon.getPokemonTypeMappings().stream()
                                 .map(PokemonTypeMapping::getPokemonType)
+                                .sorted(Comparator.comparingLong(PokemonType::getId))
                                 .distinct()
                                 .toList()
                 ));

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/ability/service/PokemonAbilityService.java
@@ -9,13 +9,12 @@ import com.pokerogue.helper.global.exception.ErrorMessage;
 import com.pokerogue.helper.global.exception.GlobalCustomException;
 import com.pokerogue.helper.pokemon.domain.Pokemon;
 import com.pokerogue.helper.pokemon.domain.PokemonAbilityMapping;
-import com.pokerogue.helper.pokemon.domain.PokemonTypeMapping;
 import com.pokerogue.helper.type.domain.PokemonType;
 import com.pokerogue.helper.type.dto.PokemonTypeResponse;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -59,14 +58,7 @@ public class PokemonAbilityService {
 
     private Map<Pokemon, List<PokemonType>> mapTypeWithPokemons(List<Pokemon> pokemons) {
         return pokemons.stream()
-                .collect(Collectors.toMap(
-                        pokemon -> pokemon,
-                        pokemon -> pokemon.getPokemonTypeMappings().stream()
-                                .map(PokemonTypeMapping::getPokemonType)
-                                .sorted(Comparator.comparingLong(PokemonType::getId))
-                                .distinct()
-                                .toList()
-                ));
+                .collect(Collectors.toMap(Function.identity(), Pokemon::getSortedPokemonTypes));
     }
 
     private List<PokemonTypeResponse> toPokemonTypeResponse(List<PokemonType> pokemonTypes) {

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/domain/Pokemon.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/domain/Pokemon.java
@@ -1,5 +1,6 @@
 package com.pokerogue.helper.pokemon.domain;
 
+import com.pokerogue.helper.type.domain.PokemonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,14 +9,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.Comparator;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "pokemon")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pokemon {
 
@@ -96,5 +100,13 @@ public class Pokemon {
         this.specialDefense = specialDefense;
         this.totalStats = totalStats;
         this.image = image;
+    }
+
+    public List<PokemonType> getSortedPokemonTypes() {
+        return this.pokemonTypeMappings.stream()
+                .map(PokemonTypeMapping::getPokemonType)
+                .sorted(Comparator.comparingLong(PokemonType::getId))
+                .distinct()
+                .toList();
     }
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/domain/Pokemon.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/domain/Pokemon.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.List;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -97,22 +96,5 @@ public class Pokemon {
         this.specialDefense = specialDefense;
         this.totalStats = totalStats;
         this.image = image;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Pokemon pokemon = (Pokemon) o;
-        return Objects.equals(name, pokemon.name);
     }
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/service/PokemonService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/service/PokemonService.java
@@ -5,7 +5,6 @@ import com.pokerogue.helper.global.exception.ErrorMessage;
 import com.pokerogue.helper.global.exception.GlobalCustomException;
 import com.pokerogue.helper.pokemon.domain.Pokemon;
 import com.pokerogue.helper.pokemon.domain.PokemonAbilityMapping;
-import com.pokerogue.helper.pokemon.domain.PokemonTypeMapping;
 import com.pokerogue.helper.pokemon.dto.PokedexResponse;
 import com.pokerogue.helper.pokemon.dto.PokemonResponse;
 import com.pokerogue.helper.pokemon.repository.PokemonRepository;
@@ -32,9 +31,7 @@ public class PokemonService {
     }
 
     private PokemonResponse toPokemonResponse(Pokemon pokemon) {
-        List<PokemonTypeMapping> pokemonTypeMappings = pokemon.getPokemonTypeMappings();
-        List<PokemonTypeResponse> pokemonTypeResponses = pokemonTypeMappings.stream()
-                .map(PokemonTypeMapping::getPokemonType)
+        List<PokemonTypeResponse> pokemonTypeResponses = pokemon.getSortedPokemonTypes().stream()
                 .map(PokemonTypeResponse::from)
                 .toList();
 
@@ -50,8 +47,7 @@ public class PokemonService {
     }
 
     private PokedexResponse toPokedexResponse(Pokemon pokemon) {
-        List<PokemonTypeResponse> pokemonTypeResponses = pokemon.getPokemonTypeMappings().stream()
-                .map(PokemonTypeMapping::getPokemonType)
+        List<PokemonTypeResponse> pokemonTypeResponses = pokemon.getSortedPokemonTypes().stream()
                 .map(PokemonTypeResponse::from)
                 .toList();
         List<PokemonAbilityResponse> pokemonAbilityResponses = pokemon.getPokemonAbilityMappings().stream()

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/type/domain/PokemonType.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/type/domain/PokemonType.java
@@ -7,12 +7,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "pokemon_type")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PokemonType {
 

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepositoryTest.java
@@ -67,6 +67,7 @@ class PokemonAbilityRepositoryTest extends RepositoryTest {
                 .map(PokemonAbilityMapping::getPokemonAbility)
                 .map(PokemonAbility::getId)
                 .collect(Collectors.toCollection(HashSet::new));
+
         return allAbilityIds.stream()
                 .filter(id -> !abilityIdsHavingPokemon.contains(id))
                 .findAny()

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepositoryTest.java
@@ -8,8 +8,12 @@ import com.pokerogue.helper.ability.domain.PokemonAbility;
 import com.pokerogue.helper.pokemon.domain.Pokemon;
 import com.pokerogue.helper.pokemon.domain.PokemonAbilityMapping;
 import com.pokerogue.helper.pokemon.domain.PokemonTypeMapping;
+import com.pokerogue.helper.pokemon.repository.PokemonAbilityMappingRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +22,9 @@ class PokemonAbilityRepositoryTest extends RepositoryTest {
 
     @Autowired
     private PokemonAbilityRepository pokemonAbilityRepository;
+
+    @Autowired
+    private PokemonAbilityMappingRepository pokemonAbilityMappingRepository;
 
     @Test
     @DisplayName("특성에 해당하는 포켓몬과 포켓몬 타입들을 조회한다.")
@@ -39,5 +46,30 @@ class PokemonAbilityRepositoryTest extends RepositoryTest {
                                 .map(PokemonTypeMapping::getPokemonType))
                         .toList()).isNotEmpty()
         );
+    }
+
+    @Test
+    @DisplayName("포켓몬이 없는 특성을 조회한다.")
+    void findByIdNotHavingPokemon() {
+        Long abilityId = findAbilityIdNotHavingPokemon();
+
+        Optional<PokemonAbility> queriedAbility = pokemonAbilityRepository.findByIdWithPokemonAndPokemonTypes(
+                abilityId);
+
+        assertThat(queriedAbility).isNotEmpty();
+    }
+
+    private Long findAbilityIdNotHavingPokemon() {
+        List<Long> allAbilityIds = pokemonAbilityRepository.findAll().stream()
+                .map(PokemonAbility::getId)
+                .toList();
+        Set<Long> abilityIdsHavingPokemon = pokemonAbilityMappingRepository.findAll().stream()
+                .map(PokemonAbilityMapping::getPokemonAbility)
+                .map(PokemonAbility::getId)
+                .collect(Collectors.toCollection(HashSet::new));
+        return allAbilityIds.stream()
+                .filter(id -> !abilityIdsHavingPokemon.contains(id))
+                .findAny()
+                .get();
     }
 }

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/repository/PokemonAbilityRepositoryTest.java
@@ -32,9 +32,9 @@ class PokemonAbilityRepositoryTest extends RepositoryTest {
         PokemonAbility pokemonAbility = pokemonAbilityRepository.findAll().get(0);
         Long pokemonAbilityId = pokemonAbility.getId();
 
-        PokemonAbility queriedPokemon = pokemonAbilityRepository.findByIdWithPokemonAndPokemonTypes(pokemonAbilityId)
+        PokemonAbility queriedAbility = pokemonAbilityRepository.findByIdWithPokemonAndPokemonTypes(pokemonAbilityId)
                 .get();
-        Set<PokemonAbilityMapping> pokemonAbilityMappings = queriedPokemon.getPokemonAbilityMappings();
+        Set<PokemonAbilityMapping> pokemonAbilityMappings = queriedAbility.getPokemonAbilityMappings();
         List<Pokemon> pokemons = pokemonAbilityMappings.stream()
                 .map(PokemonAbilityMapping::getPokemon)
                 .toList();

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/service/PokemonAbilityServiceTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/ability/service/PokemonAbilityServiceTest.java
@@ -1,19 +1,25 @@
 package com.pokerogue.helper.ability.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.pokerogue.environment.service.ServiceTest;
 import com.pokerogue.helper.ability.dto.PokemonAbilityWithPokemonsResponse;
 import com.pokerogue.helper.ability.dto.SameAbilityPokemonResponse;
 import com.pokerogue.helper.ability.repository.PokemonAbilityRepository;
 import com.pokerogue.helper.global.exception.ErrorMessage;
 import com.pokerogue.helper.global.exception.GlobalCustomException;
+import com.pokerogue.helper.type.domain.PokemonType;
+import com.pokerogue.helper.type.dto.PokemonTypeResponse;
+import com.pokerogue.helper.type.repository.PokemonTypeRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PokemonAbilityServiceTest extends ServiceTest {
 
@@ -22,6 +28,9 @@ class PokemonAbilityServiceTest extends ServiceTest {
 
     @Autowired
     private PokemonAbilityRepository pokemonAbilityRepository;
+
+    @Autowired
+    private PokemonTypeRepository pokemonTypeRepository;
 
     @Test
     @DisplayName("존재하지 않는 포켓몬의 특성을 조회하면 예외가 발생한다.")
@@ -36,11 +45,41 @@ class PokemonAbilityServiceTest extends ServiceTest {
     void findPokemonsOrderByIdInAbilityDetails() {
         Long abilityId = pokemonAbilityRepository.findAll().get(0).getId();
 
-        PokemonAbilityWithPokemonsResponse pokemonAbilityWithPokemons = pokemonAbilityService.findAbilityDetails(abilityId);
+        PokemonAbilityWithPokemonsResponse pokemonAbilityWithPokemons = pokemonAbilityService.findAbilityDetails(
+                abilityId);
 
         List<Long> pokemonIds = pokemonAbilityWithPokemons.pokemons().stream()
                 .map(SameAbilityPokemonResponse::id)
                 .toList();
         assertThat(pokemonIds).isSortedAccordingTo(Long::compare);
+    }
+
+    @Test
+    @DisplayName("같은 특성을 가진 포켓몬 목록을 조회할 때 포켓몬의 타입을 id 순으로 정렬한다.")
+    void findPokemonsWithTypesOrderByIdInAbilityDetails() {
+        Long abilityId = pokemonAbilityRepository.findAll().get(0).getId();
+
+        PokemonAbilityWithPokemonsResponse pokemonAbilityWithPokemons = pokemonAbilityService.findAbilityDetails(
+                abilityId);
+
+        List<List<String>> pokemonTypeNamesInResponse = pokemonTypeNamesGroupByPokemon(pokemonAbilityWithPokemons);
+        Map<String, Long> allPokemonTypeNamesWithId = findAllPokemonTypeNamesWithId();
+        assertAll(() -> pokemonTypeNamesInResponse.forEach(typeNames ->
+                assertThat(typeNames).isSortedAccordingTo(Comparator.comparingLong(allPokemonTypeNamesWithId::get))));
+    }
+
+    private List<List<String>> pokemonTypeNamesGroupByPokemon(
+            PokemonAbilityWithPokemonsResponse pokemonAbilityWithPokemons) {
+        return pokemonAbilityWithPokemons.pokemons().stream()
+                .map(SameAbilityPokemonResponse::pokemonTypeResponses)
+                .map(pokemonTypeResponses -> pokemonTypeResponses.stream()
+                        .map(PokemonTypeResponse::pokemonTypeName)
+                        .toList())
+                .toList();
+    }
+
+    private Map<String, Long> findAllPokemonTypeNamesWithId() {
+        return pokemonTypeRepository.findAll().stream()
+                .collect(Collectors.toMap(PokemonType::getName, PokemonType::getId));
     }
 }

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/pokemon/domain/PokemonTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/pokemon/domain/PokemonTest.java
@@ -1,0 +1,31 @@
+package com.pokerogue.helper.pokemon.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.pokerogue.helper.type.domain.PokemonType;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PokemonTest {
+
+    @Test
+    @DisplayName("포켓몬의 타입 목록을 id 순으로 조회한다.")
+    void getSortedPokemonTypes() {
+        List<PokemonType> pokemonTypes = List.of(
+                new PokemonType(2L, "grass", "풀", "grass dummy image"),
+                new PokemonType(1L, "poison", "독", "poison dummy image")
+        );
+        List<PokemonTypeMapping> pokemonTypeMappings = pokemonTypes.stream()
+                .map(type -> new PokemonTypeMapping(null, type))
+                .toList();
+        Pokemon pokemon = new Pokemon(1L, 1L, "이상해씨", "이상해씨", 6.9, 0.7, 45, 45, 55, 50, 60, 70, 500,
+                "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png", pokemonTypeMappings,
+                List.of());
+
+        List<PokemonType> sortedPokemonTypes = pokemon.getSortedPokemonTypes();
+
+        assertThat(sortedPokemonTypes).isSortedAccordingTo(Comparator.comparingLong(PokemonType::getId));
+    }
+}


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [ ] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #171, #169

- [x] 포켓몬이 없는 특성 상세 정보 반환 api에서 404 대신 정상 응답 반환
- [x] 포켓몬 상세 정보 페이지, 도감 목록 페이지, 특성 상세 페이지에서 타입 id 정렬

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [x] 있음
- [ ] 없음

PokemonTest 하려다보니 몇 엔티티 클래스에 `@AllArgsConstructor` 추가되었습니다. 테스트를 위한 생성자 추가에 반대하시는 분은 당근을 흔들어주세요 .. 🥕