### PR TITLE
[0.1.30-alpha/AN-FIX, AN_UI] 포켓몬 디테일 화면 가로 화면 대응

### DIFF
--- a/android/app/src/main/res/layout-land/fragment_pokemon_detail.xml
+++ b/android/app/src/main/res/layout-land/fragment_pokemon_detail.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="poke.rogue.helper.presentation.dex.detail.PokemonDetailViewModel" />
+
+        <variable
+            name="eventHandler"
+            type="poke.rogue.helper.presentation.dex.detail.PokemonDetailNavigateHandler" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.dex.detail.PokemonDetailFragment">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_dex_detail"
+            style="@style/CustomToolbarStyle"
+            android:layout_width="0dp"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@string/dex_title_name">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|center_vertical"
+                android:onClick="@{() -> eventHandler.navigateToHome()}"
+                android:padding="12dp"
+                android:src="@drawable/icon_home" />
+        </com.google.android.material.appbar.MaterialToolbar>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_dex_detail">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/gl_pokemon_detail_image_end"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layout_constraintGuide_percent="0.4" />
+
+                <ImageView
+                    android:id="@+id/iv_pokemon_detail_pokemon"
+                    android:layout_width="200dp"
+                    android:layout_height="200dp"
+                    android:translationZ="10dp"
+                    app:layout_constraintBottom_toTopOf="@id/tv_pokemon_detail_pokemon_name"
+                    app:layout_constraintDimensionRatio="1"
+                    app:layout_constraintEnd_toEndOf="@id/gl_pokemon_detail_image_end"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:src="@tools:sample/avatars" />
+
+
+                <com.google.android.material.progressindicator.CircularProgressIndicator
+                    android:id="@+id/progress_indicator_pokemon_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:indeterminate="true"
+                    android:visibility="gone"
+                    app:indicatorColor="@color/poke_grey_20"
+                    app:layout_constraintBottom_toBottomOf="@+id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintEnd_toEndOf="@+id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintStart_toStartOf="@+id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintTop_toTopOf="@+id/iv_pokemon_detail_pokemon"
+                    tools:visibility="visible" />
+
+                <TextView
+                    android:id="@+id/tv_pokemon_detail_pokemon_name"
+                    style="@style/TextAppearance.Poke.TitleBold"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="16dp"
+                    android:textSize="28sp"
+                    app:layout_constraintBottom_toBottomOf="@id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintEnd_toEndOf="@id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintStart_toStartOf="@id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintTop_toBottomOf="@+id/iv_pokemon_detail_pokemon"
+                    tools:text="이상해씨 #1" />
+
+                <LinearLayout
+                    android:id="@+id/layout_pokemon_detail_pokemon_types"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="@id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintStart_toStartOf="@id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintTop_toBottomOf="@id/tv_pokemon_detail_pokemon_name"
+                    tools:layout_height="50dp" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_pokemon_abilities"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="10dp"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintBottom_toTopOf="@id/layout_stats"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.506"
+                    app:layout_constraintStart_toEndOf="@+id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintTop_toTopOf="@id/iv_pokemon_detail_pokemon"
+                    tools:itemCount="4"
+                    tools:listitem="@layout/item_ability_title">
+
+                </androidx.recyclerview.widget.RecyclerView>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_stats"
+                    visible="@{!vm.isEmpty()}"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="10dp"
+                    android:background="@drawable/shape_grey_80_fill_20_rect"
+                    android:paddingBottom="20dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.473"
+                    app:layout_constraintStart_toEndOf="@id/iv_pokemon_detail_pokemon"
+                    app:layout_constraintTop_toBottomOf="@+id/rv_pokemon_abilities">
+
+                    <TextView
+                        android:id="@+id/tv_title_stats"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:fontFamily="@font/pretendard_semibold"
+                        android:text="기본 스탯"
+                        android:textSize="20sp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/rv_stat_list"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginTop="8dp"
+                        android:orientation="vertical"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                        app:layout_constraintTop_toBottomOf="@id/tv_title_stats"
+                        tools:itemCount="5"
+                        tools:listitem="@layout/item_stat" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -3,8 +3,8 @@ applicationId = "poke.rogue.helper"
 compileSdk = "34"
 minSdk = "26"
 targetSdk = "34"
-appVersion = "0.1.20"
-versionCode = "00120"
+appVersion = "0.1.30"
+versionCode = "00130"
 agp = "8.3.2"
 
 # kotlin


### PR DESCRIPTION
- closed #170 
## 작업 영상
[pokemon_detail_landscape.webm](https://github.com/user-attachments/assets/ee7d01ac-807d-43c2-9b58-a8ed81c3fee0)


## 작업한 내용
- 포켓몬 상세 landscape

## PR 포인트
- 특성 디테일쪽이랑 똑같이 guideline 설정해서 만들었습니다.

## 🚀Next Feature
- 데모데이 이후에 결정