### PR TITLE
[1.1.0.alpha/AN-FIX] 바이옴 디테일 페이지 UI 수정

### DIFF
--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/boss/BiomeBossFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/boss/BiomeBossFragment.kt
@@ -36,6 +36,9 @@ class BiomeBossFragment :
     private fun initObservers() {
         repeatOnStarted {
             viewModel.uiState.collect { state ->
+                state.bossPokemons.isEmpty().let {
+                    binding.biomeDetailEmpty.visibility = if (it) View.VISIBLE else View.GONE
+                }
                 bossPokemonAdapter.submitList(state.bossPokemons)
             }
         }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/boss/BiomeBossFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/boss/BiomeBossFragment.kt
@@ -10,6 +10,7 @@ import poke.rogue.helper.presentation.base.error.ErrorHandleFragment
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
 import poke.rogue.helper.presentation.biome.detail.BiomeDetailViewModel
 import poke.rogue.helper.presentation.util.repeatOnStarted
+import poke.rogue.helper.presentation.util.view.setVisible
 
 class BiomeBossFragment :
     ErrorHandleFragment<FragmentBiomeBossPokemonBinding>(R.layout.fragment_biome_boss_pokemon) {
@@ -37,7 +38,7 @@ class BiomeBossFragment :
         repeatOnStarted {
             viewModel.uiState.collect { state ->
                 state.bossPokemons.isEmpty().let {
-                    binding.biomeDetailEmpty.visibility = if (it) View.VISIBLE else View.GONE
+                    binding.biomeDetailBossEmpty.setVisible(it)
                 }
                 bossPokemonAdapter.submitList(state.bossPokemons)
             }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/gym/BiomeGymFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/gym/BiomeGymFragment.kt
@@ -36,6 +36,9 @@ class BiomeGymFragment :
     private fun initObservers() {
         repeatOnStarted {
             viewModel.uiState.collect { state ->
+                state.gymPokemons.isEmpty().let {
+                    binding.biomeDetailEmpty.visibility = if (it) View.VISIBLE else View.GONE
+                }
                 gymPokemonAdapter.submitList(state.gymPokemons)
             }
         }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/gym/BiomeGymFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/gym/BiomeGymFragment.kt
@@ -10,6 +10,7 @@ import poke.rogue.helper.presentation.base.error.ErrorHandleFragment
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
 import poke.rogue.helper.presentation.biome.detail.BiomeDetailViewModel
 import poke.rogue.helper.presentation.util.repeatOnStarted
+import poke.rogue.helper.presentation.util.view.setVisible
 
 class BiomeGymFragment :
     ErrorHandleFragment<FragmentBiomeGymPokemonBinding>(R.layout.fragment_biome_gym_pokemon) {
@@ -37,7 +38,7 @@ class BiomeGymFragment :
         repeatOnStarted {
             viewModel.uiState.collect { state ->
                 state.gymPokemons.isEmpty().let {
-                    binding.biomeDetailEmpty.visibility = if (it) View.VISIBLE else View.GONE
+                    binding.biomeDetailGymEmpty.setVisible(it)
                 }
                 gymPokemonAdapter.submitList(state.gymPokemons)
             }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/wild/BiomeWildViewHolder.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/detail/wild/BiomeWildViewHolder.kt
@@ -15,11 +15,14 @@ class BiomeWildViewHolder(
     RecyclerView.ViewHolder(binding.root) {
     private val pokemonAdapter: BiomPokemonAdapter by lazy { BiomPokemonAdapter(onClickPokemon) }
 
+    init {
+        val decoration = GridSpacingItemDecoration(3, 18.dp, false)
+        binding.rvBiomeWildPokemon.addItemDecoration(decoration)
+    }
+
     fun bind(wildPokemon: BiomePokemonUiModel) {
         binding.biomePokemon = wildPokemon
 
-        val decoration = GridSpacingItemDecoration(3, 18.dp, false)
-        binding.rvBiomeWildPokemon.addItemDecoration(decoration)
         wildPokemon.pokemons.let(pokemonAdapter::submitList)
         binding.rvBiomeWildPokemon.adapter = pokemonAdapter
     }

--- a/android/app/src/main/res/layout/fragment_biome_boss_pokemon.xml
+++ b/android/app/src/main/res/layout/fragment_biome_boss_pokemon.xml
@@ -21,7 +21,7 @@
             tools:listitem="@layout/item_biome_pokemon" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/biome_detail_empty"
+            android:id="@+id/biome_detail_boss_empty"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -34,18 +34,17 @@
                 android:layout_height="170dp"
                 android:layout_marginBottom="10dp"
                 android:src="@drawable/ic_ditto_silhouette"
-                app:layout_constraintBottom_toTopOf="@id/tv_empty"
+                app:layout_constraintBottom_toTopOf="@id/tv_biome_detail_boss_empty"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 tools:ignore="ContentDescription" />
 
             <TextView
-                android:id="@+id/tv_empty"
+                android:id="@+id/tv_biome_detail_boss_empty"
                 style="@style/TextAppearance.Poke.TitleLarge"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/biome_detail_boss"
-                android:textSize="28sp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />

--- a/android/app/src/main/res/layout/fragment_biome_boss_pokemon.xml
+++ b/android/app/src/main/res/layout/fragment_biome_boss_pokemon.xml
@@ -7,13 +7,49 @@
 
     </data>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_biome_boss"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/poke_grey_80"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:listitem="@layout/item_biome_pokemon" />
+        android:background="@color/poke_grey_80">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_biome_boss"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:listitem="@layout/item_biome_pokemon" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/biome_detail_empty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:layout_width="170dp"
+                android:layout_height="170dp"
+                android:layout_marginBottom="10dp"
+                android:src="@drawable/ic_ditto_silhouette"
+                app:layout_constraintBottom_toTopOf="@id/tv_empty"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:ignore="ContentDescription" />
+
+            <TextView
+                android:id="@+id/tv_empty"
+                style="@style/TextAppearance.Poke.TitleLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/biome_detail_boss"
+                android:textSize="28sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/android/app/src/main/res/layout/fragment_biome_gym_pokemon.xml
+++ b/android/app/src/main/res/layout/fragment_biome_gym_pokemon.xml
@@ -21,7 +21,7 @@
             tools:listitem="@layout/item_biome_gym" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/biome_detail_empty"
+            android:id="@+id/biome_detail_gym_empty"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -34,18 +34,17 @@
                 android:layout_height="170dp"
                 android:layout_marginBottom="10dp"
                 android:src="@drawable/ic_ditto_silhouette"
-                app:layout_constraintBottom_toTopOf="@id/tv_empty"
+                app:layout_constraintBottom_toTopOf="@id/tv_biome_detail_gym_empty"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 tools:ignore="ContentDescription" />
 
             <TextView
-                android:id="@+id/tv_empty"
+                android:id="@+id/tv_biome_detail_gym_empty"
                 style="@style/TextAppearance.Poke.TitleLarge"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/biome_detail_gym"
-                android:textSize="28sp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />

--- a/android/app/src/main/res/layout/fragment_biome_gym_pokemon.xml
+++ b/android/app/src/main/res/layout/fragment_biome_gym_pokemon.xml
@@ -7,13 +7,49 @@
 
     </data>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_biome_gym"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/poke_grey_80"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:listitem="@layout/item_biome_gym" />
+        android:background="@color/poke_grey_80">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_biome_gym"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:listitem="@layout/item_biome_gym" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/biome_detail_empty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:layout_width="170dp"
+                android:layout_height="170dp"
+                android:layout_marginBottom="10dp"
+                android:src="@drawable/ic_ditto_silhouette"
+                app:layout_constraintBottom_toTopOf="@id/tv_empty"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:ignore="ContentDescription" />
+
+            <TextView
+                android:id="@+id/tv_empty"
+                style="@style/TextAppearance.Poke.TitleLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/biome_detail_gym"
+                android:textSize="28sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/android/app/src/main/res/layout/item_biome_next_biomes.xml
+++ b/android/app/src/main/res/layout/item_biome_next_biomes.xml
@@ -8,17 +8,18 @@
         <variable
             name="nextBiome"
             type="poke.rogue.helper.presentation.biome.model.NextBiomeUiModel" />
+
         <variable
             name="handler"
             type="poke.rogue.helper.presentation.biome.detail.BiomeDetailHandler" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        onSingleClick="@{view -> handler.navigateToBiomeDetail(nextBiome.biome.id)}"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/shape_pokemon_corner_radius"
-        android:paddingHorizontal="30dp"
-        onSingleClick="@{view -> handler.navigateToBiomeDetail(nextBiome.biome.id)}"
+        android:paddingHorizontal="50dp"
         android:paddingVertical="15dp">
 
         <TextView
@@ -26,9 +27,8 @@
             style="@style/TextAppearance.Poke.TitleLargeBold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="30dp"
             android:text="@{nextBiome.biome.name}"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/iv_biome"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="화산" />
 
@@ -46,9 +46,8 @@
             style="@style/TextAppearance.Poke.TitleLargeBold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="30dp"
             android:text="@{Double.toString(nextBiome.probability) + '%'}"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/iv_biome"
             app:layout_constraintTop_toTopOf="@id/tv_biome_name"
             tools:text="33%" />
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -96,6 +96,9 @@
     <!--    biome detail gym -->
     <string name="biome_detail_gym">등장하는 체육관 관장이 없어요</string>
 
+    <!--    biome detail boss -->
+    <string name="biome_detail_boss">등장하는 보스 포켓몬이 없어요</string>
+
     <!--    item -->
     <string name="item_title_name">아이템 도감</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -93,6 +93,9 @@
         <item>다음 바이옴</item>
     </string-array>
 
+    <!--    biome detail gym -->
+    <string name="biome_detail_gym">등장하는 체육관 관장이 없어요</string>
+
     <!--    item -->
     <string name="item_title_name">아이템 도감</string>
 

--- a/android/local/src/androidTest/java/poke/rogue/helper/local/entity/PokemonFixtures.kt
+++ b/android/local/src/androidTest/java/poke/rogue/helper/local/entity/PokemonFixtures.kt
@@ -30,5 +30,6 @@ fun pokemonEntity(
         specialAttack = specialAttack,
         specialDefense = specialDefense,
         speed = speed,
+        backImageUrl = imageUrl,
         formName = formName,
     )


### PR DESCRIPTION
- closed #296 
## 작업 
[an:ui:바이옴디테일 (1.1.0) fix.webm](https://github.com/user-attachments/assets/d78c0eac-522b-4456-ae53-f833b6af78d0)

## 작업한 내용
- 야생 포켓몬 탭에서 스크롤 시, 포켓몬의 크기가 작아지는 이슈 해결했습니다.
- 탭에 해당하는 데이터가 없을 시, empty view 추가 했습니다.
- 다음 바이옴 탭에서 이름과 이미지의 간격 수정하였습니다. 

## PR 포인트
- 그런 건 없어요~~

## 🚀Next Feature
- biome detail toolbar 이름 수정
