### PR TITLE
[1.1.0/AN_FEAT,AN_UI] 바이옴 전체 지도 toolbar에 웹뷰 구현 

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -68,7 +68,7 @@
             android:exported="false" />
 
         <activity
-            android:name=".presentation.biome.BiomeGuideActivity"
+            android:name=".presentation.biome.guide.BiomeGuideActivity"
             android:exported="false" />
     </application>
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -66,6 +66,10 @@
         <activity
             android:name=".presentation.dex.detail.PokemonDetailActivity"
             android:exported="false" />
+
+        <activity
+            android:name=".presentation.biome.BiomeGuideActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeActivity.kt
@@ -12,6 +12,7 @@ import poke.rogue.helper.databinding.ActivityBiomeBinding
 import poke.rogue.helper.presentation.base.error.ErrorHandleActivity
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
 import poke.rogue.helper.presentation.biome.detail.BiomeDetailActivity
+import poke.rogue.helper.presentation.biome.guide.BiomeGuideActivity
 import poke.rogue.helper.presentation.biome.model.toUi
 import poke.rogue.helper.presentation.util.context.startActivity
 import poke.rogue.helper.presentation.util.logClickEvent

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeActivity.kt
@@ -1,7 +1,6 @@
 package poke.rogue.helper.presentation.biome
 
 import android.os.Bundle
-import android.webkit.WebView
 import androidx.activity.viewModels
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeActivity.kt
@@ -1,6 +1,7 @@
 package poke.rogue.helper.presentation.biome
 
 import android.os.Bundle
+import android.webkit.WebView
 import androidx.activity.viewModels
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
@@ -69,6 +70,14 @@ class BiomeActivity : ErrorHandleActivity<ActivityBiomeBinding>(R.layout.activit
         }
 
         repeatOnStarted {
+            viewModel.navigateToGuideEvent.collect {
+                startActivity<BiomeGuideActivity> {
+                    logger.logClickEvent(NAVIGATE_TO_BIOME_GUIDE)
+                }
+            }
+        }
+
+        repeatOnStarted {
             viewModel.biome.collect { biome ->
                 when (biome) {
                     is BiomeUiState.Loading -> {
@@ -86,5 +95,6 @@ class BiomeActivity : ErrorHandleActivity<ActivityBiomeBinding>(R.layout.activit
 
     companion object {
         private const val NAVIGATE_TO_BIOME_DETAIL = "Nav_Biome_Detail"
+        private const val NAVIGATE_TO_BIOME_GUIDE = "Nav_Biome_Guide"
     }
 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeGuideActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeGuideActivity.kt
@@ -1,7 +1,6 @@
 package poke.rogue.helper.presentation.biome
 
 import android.os.Bundle
-import android.webkit.WebViewClient
 import poke.rogue.helper.R
 import poke.rogue.helper.databinding.ActivityBiomeGuideBinding
 import poke.rogue.helper.presentation.base.BindingActivity
@@ -9,7 +8,6 @@ import poke.rogue.helper.presentation.util.context.stringOf
 
 class BiomeGuideActivity :
     BindingActivity<ActivityBiomeGuideBinding>(R.layout.activity_biome_guide) {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initView()

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeGuideActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeGuideActivity.kt
@@ -1,0 +1,24 @@
+package poke.rogue.helper.presentation.biome
+
+import android.os.Bundle
+import android.webkit.WebViewClient
+import poke.rogue.helper.R
+import poke.rogue.helper.databinding.ActivityBiomeGuideBinding
+import poke.rogue.helper.presentation.base.BindingActivity
+import poke.rogue.helper.presentation.util.context.stringOf
+
+class BiomeGuideActivity :
+    BindingActivity<ActivityBiomeGuideBinding>(R.layout.activity_biome_guide) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initView()
+    }
+
+    private fun initView() {
+        with(binding.wvBiomeGuide) {
+            settings.loadWithOverviewMode = true
+            loadUrl(stringOf(R.string.biome_guide_url))
+        }
+    }
+}

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeUiEventHandler.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeUiEventHandler.kt
@@ -2,4 +2,6 @@ package poke.rogue.helper.presentation.biome
 
 interface BiomeUiEventHandler {
     fun navigateToDetail(biomeId: String)
+
+    fun navigateToGuide()
 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeViewModel.kt
@@ -23,12 +23,15 @@ class BiomeViewModel(
     logger: AnalyticsLogger = analyticsLogger(),
 ) :
     ErrorHandleViewModel(logger),
-        BiomeUiEventHandler {
+    BiomeUiEventHandler {
     private val _biome = MutableStateFlow<BiomeUiState<List<Biome>>>(BiomeUiState.Loading)
     val biome = _biome.asStateFlow()
 
     private val _navigationToDetailEvent = MutableSharedFlow<String>()
     val navigationToDetailEvent: SharedFlow<String> = _navigationToDetailEvent.asSharedFlow()
+
+    private val _navigateToGuideEvent = MutableSharedFlow<Unit>()
+    val navigateToGuideEvent: SharedFlow<Unit> = _navigateToGuideEvent.asSharedFlow()
 
     init {
         refreshEvent
@@ -49,6 +52,12 @@ class BiomeViewModel(
     override fun navigateToDetail(biomeId: String) {
         viewModelScope.launch {
             _navigationToDetailEvent.emit(biomeId)
+        }
+    }
+
+    override fun navigateToGuide() {
+        viewModelScope.launch {
+            _navigateToGuideEvent.emit(Unit)
         }
     }
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/BiomeViewModel.kt
@@ -23,7 +23,7 @@ class BiomeViewModel(
     logger: AnalyticsLogger = analyticsLogger(),
 ) :
     ErrorHandleViewModel(logger),
-    BiomeUiEventHandler {
+        BiomeUiEventHandler {
     private val _biome = MutableStateFlow<BiomeUiState<List<Biome>>>(BiomeUiState.Loading)
     val biome = _biome.asStateFlow()
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/biome/guide/BiomeGuideActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/biome/guide/BiomeGuideActivity.kt
@@ -1,13 +1,17 @@
-package poke.rogue.helper.presentation.biome
+package poke.rogue.helper.presentation.biome.guide
 
 import android.os.Bundle
+import androidx.appcompat.widget.Toolbar
 import poke.rogue.helper.R
 import poke.rogue.helper.databinding.ActivityBiomeGuideBinding
-import poke.rogue.helper.presentation.base.BindingActivity
+import poke.rogue.helper.presentation.base.toolbar.ToolbarActivity
 import poke.rogue.helper.presentation.util.context.stringOf
 
 class BiomeGuideActivity :
-    BindingActivity<ActivityBiomeGuideBinding>(R.layout.activity_biome_guide) {
+    ToolbarActivity<ActivityBiomeGuideBinding>(R.layout.activity_biome_guide) {
+    override val toolbar: Toolbar
+        get() = binding.toolbarBiomeGuide
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initView()

--- a/android/app/src/main/res/drawable/ic_biome_map.xml
+++ b/android/app/src/main/res/drawable/ic_biome_map.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#DDDDDD"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z" />
+
+</vector>

--- a/android/app/src/main/res/layout/activity_biome.xml
+++ b/android/app/src/main/res/layout/activity_biome.xml
@@ -23,7 +23,18 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:title="@string/biome_title_name" />
+            app:title="@string/biome_title_name">
+
+            <ImageView
+                android:id="@+id/iv_biome_guide"
+                onSingleClick="@{() -> vm.navigateToGuide()}"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|center_vertical"
+                android:padding="12dp"
+                android:src="@drawable/ic_biome_map" />
+
+        </com.google.android.material.appbar.MaterialToolbar>
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_biome_list"

--- a/android/app/src/main/res/layout/activity_biome_detail.xml
+++ b/android/app/src/main/res/layout/activity_biome_detail.xml
@@ -23,27 +23,17 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:title="@string/biome_title_name" />
-
-        <TextView
-            android:id="@+id/tv_biome_detail_title"
-            style="@style/TextAppearance.Poke.TitleLargeBold"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingHorizontal="30dp"
-            android:text="@{vm.uiState.name}"
-            app:layout_constraintStart_toStartOf="@id/iv_biome_detail_image"
-            app:layout_constraintTop_toBottomOf="@id/toolbar_biome_detail"
-            tools:text="눈덮인 숲" />
+            app:title="@{vm.uiState.name}" />
 
         <ImageView
+            android:layout_marginTop="20dp"
             android:id="@+id/iv_biome_detail_image"
             imageUrl="@{vm.uiState.imageUrl}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="@id/gl_end"
             app:layout_constraintStart_toStartOf="@id/gl_start"
-            app:layout_constraintTop_toBottomOf="@id/tv_biome_detail_title"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_biome_detail"
             tools:srcCompat="@tools:sample/avatars" />
 
         <com.google.android.material.tabs.TabLayout

--- a/android/app/src/main/res/layout/activity_biome_guide.xml
+++ b/android/app/src/main/res/layout/activity_biome_guide.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <WebView
+            android:id="@+id/wv_biome_guide"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/activity_biome_guide.xml
+++ b/android/app/src/main/res/layout/activity_biome_guide.xml
@@ -10,6 +10,14 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_biome_guide"
+            style="@style/CustomToolbarStyle"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@string/biome_title_name" />
+
         <WebView
             android:id="@+id/wv_biome_guide"
             android:layout_width="0dp"
@@ -17,7 +25,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/toolbar_biome_guide" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/item_biome_next_biomes.xml
+++ b/android/app/src/main/res/layout/item_biome_next_biomes.xml
@@ -46,7 +46,7 @@
             style="@style/TextAppearance.Poke.TitleLargeBold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{Double.toString(nextBiome.probability) + '%'}"
+            android:text="@{String.format(@string/biome_detail_next_biome_probability, nextBiome.probability)}"
             app:layout_constraintEnd_toEndOf="@id/iv_biome"
             app:layout_constraintTop_toTopOf="@id/tv_biome_name"
             tools:text="33%" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -100,6 +100,9 @@
     <!--    biome detail boss -->
     <string name="biome_detail_boss">등장하는 보스 포켓몬이 없어요</string>
 
+    <!--    biome detail next biome -->
+    <string name="biome_detail_next_biome_probability">%.1f%%</string>
+
     <!--    item -->
     <string name="item_title_name">아이템 도감</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
 
     <!--    biome -->
     <string name="biome_title_name">바이옴 도감</string>
+    <string name="biome_guide_url">https://bluedell.com/%ED%8F%AC%EC%BC%93%EB%A1%9C%EA%B7%B8-%EB%B0%94%EC%9D%B4%EC%98%B4/</string>
     <string-array name="biome_tab_titles">
         <item>체육관</item>
         <item>보스</item>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@
 
     <!--    biome -->
     <string name="biome_title_name">바이옴 도감</string>
-    <string name="biome_guide_url">https://bluedell.com/%ED%8F%AC%EC%BC%93%EB%A1%9C%EA%B7%B8-%EB%B0%94%EC%9D%B4%EC%98%B4/</string>
+    <string name="biome_guide_url">https://wiki.pokerogue.net/ko:biomes:biomes</string>
     <string-array name="biome_tab_titles">
         <item>체육관</item>
         <item>보스</item>

--- a/android/app/src/test/java/poke/rogue/helper/presentation/biome/BiomeViewModelTest.kt
+++ b/android/app/src/test/java/poke/rogue/helper/presentation/biome/BiomeViewModelTest.kt
@@ -53,4 +53,19 @@ class BiomeViewModelTest {
             // then
             actualId shouldBe biomeId
         }
+
+    @Test
+    fun `바이옴 가이드 화면으로 이동한다`() =
+        runTest {
+            // given
+            Dispatchers.setMain(StandardTestDispatcher())
+            viewModel = BiomeViewModel(repository)
+
+            // when
+            viewModel.navigateToGuide()
+            val actual = viewModel.navigateToGuideEvent.first()
+
+            // then
+            actual shouldBe Unit
+        }
 }


### PR DESCRIPTION
- close #304 
## 작업 영상
[an:feat:바이옴웹뷰구현.webm](https://github.com/user-attachments/assets/b5351321-6c93-49c8-ab11-968d3d307d20)

## 작업한 내용
- toolbar의 제목을 바이옴 디테일에 해당하는 이름으로 변경했습니다.
- 바이옴 리스트 화면에서 깃발모양 클릭 시, 웹뷰로 이동하도록 추가했습니다.

## PR 포인트
- 그런건 없어요~

## 🚀Next Feature
- 바이옴 검색 기능 구현