### PR TITLE
[1.1.0/AN_FIX] 배틀 디테일 로직 수정

### DIFF
--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/AnalyticsExtensions.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/AnalyticsExtensions.kt
@@ -4,7 +4,6 @@ import poke.rogue.helper.analytics.AnalyticsEvent
 import poke.rogue.helper.analytics.AnalyticsLogger
 import poke.rogue.helper.presentation.battle.model.SelectionData
 
-// TODO : 조대리님 적용해주세요
 fun AnalyticsLogger.logPokemonSkillSelection(selection: SelectionData.WithSkill) {
     val eventType = "pokemon_battle_skill_selection"
     logEvent(
@@ -15,7 +14,6 @@ fun AnalyticsLogger.logPokemonSkillSelection(selection: SelectionData.WithSkill)
     )
 }
 
-// TODO : 조대리님 적용해주세요
 fun AnalyticsLogger.logBattlePokemonSelection(selection: SelectionData.WithoutSkill) {
     val eventType = "pokemon_battle_selection"
     logEvent(

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleActivity.kt
@@ -83,23 +83,23 @@ class BattleActivity : ToolbarActivity<ActivityBattleBinding>(R.layout.activity_
         repeatOnStarted {
             viewModel.selectedState.collect {
                 if (it.minePokemon is BattleSelectionUiState.Selected) {
-                    val selected = it.minePokemon.selected
+                    val selected = it.minePokemon.content
                     binding.ivMinePokemon.setImage(selected.backImageUrl)
                     binding.tvMinePokemon.text = selected.name
                 }
 
                 if (it.skill is BattleSelectionUiState.Selected) {
-                    binding.tvSkillTitle.text = it.skill.selected.name
+                    binding.tvSkillTitle.text = it.skill.content.name
                 }
 
                 if (it.opponentPokemon is BattleSelectionUiState.Selected) {
-                    val selected = it.opponentPokemon.selected
+                    val selected = it.opponentPokemon.content
                     binding.ivOpponentPokemon.setImage(selected.frontImageUrl)
                     binding.tvOpponentPokemon.text = selected.name
                 }
 
                 if (it.weather is BattleSelectionUiState.Selected) {
-                    val selected = it.weather.selected
+                    val selected = it.weather.content
                     binding.tvWeatherDescription.text = selected.effect
                 }
             }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleNavigationHandler.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleNavigationHandler.kt
@@ -1,5 +1,7 @@
 package poke.rogue.helper.presentation.battle
 
+import poke.rogue.helper.presentation.battle.model.SelectionMode
+
 interface BattleNavigationHandler {
-    fun navigateToSelection(hasSkillSelection: Boolean)
+    fun navigateToSelection(selectionMode: SelectionMode)
 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionUiState.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionUiState.kt
@@ -1,18 +1,11 @@
 package poke.rogue.helper.presentation.battle
 
 sealed interface BattleSelectionUiState<out T : Any> {
-    data class Selected<T : Any>(val selected: T) : BattleSelectionUiState<T>
+    data class Selected<T : Any>(val content: T) : BattleSelectionUiState<T>
 
     data object Empty : BattleSelectionUiState<Nothing>
 }
 
 fun <T : Any> BattleSelectionUiState<T>.isSelected(): Boolean = this is BattleSelectionUiState.Selected
 
-fun <T : Any> BattleSelectionUiState<T>.selectedData(): T? = (this as? BattleSelectionUiState.Selected)?.selected
-
-fun <T : Any> BattleSelectionUiState<T>.requireSelectedData(errorMessage: String): T {
-    return when (this) {
-        is BattleSelectionUiState.Selected -> selected
-        is BattleSelectionUiState.Empty -> throw IllegalArgumentException(errorMessage)
-    }
-}
+fun <T : Any> BattleSelectionUiState<T>.selectedData(): T? = (this as? BattleSelectionUiState.Selected)?.content

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionUiState.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionUiState.kt
@@ -1,7 +1,8 @@
 package poke.rogue.helper.presentation.battle
 
 sealed interface BattleSelectionUiState<out T : Any> {
-    data class Selected<T : Any>(val selected: T) : BattleSelectionUiState<T>
+    data class Selected<T : Any>(val selected: T, val hasSelectionChanged: Boolean = false) :
+        BattleSelectionUiState<T>
 
     data object Empty : BattleSelectionUiState<Nothing>
 }
@@ -9,3 +10,6 @@ sealed interface BattleSelectionUiState<out T : Any> {
 fun <T : Any> BattleSelectionUiState<T>.isSelected(): Boolean = this is BattleSelectionUiState.Selected
 
 fun <T : Any> BattleSelectionUiState<T>.selectedData(): T? = (this as? BattleSelectionUiState.Selected)?.selected
+
+fun <T : Any> BattleSelectionUiState<T>.hasSelectedChanged(): Boolean =
+    (this as? BattleSelectionUiState.Selected)?.hasSelectionChanged == true

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionUiState.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionUiState.kt
@@ -1,8 +1,7 @@
 package poke.rogue.helper.presentation.battle
 
 sealed interface BattleSelectionUiState<out T : Any> {
-    data class Selected<T : Any>(val selected: T, val hasSelectionChanged: Boolean = false) :
-        BattleSelectionUiState<T>
+    data class Selected<T : Any>(val selected: T) : BattleSelectionUiState<T>
 
     data object Empty : BattleSelectionUiState<Nothing>
 }
@@ -11,5 +10,9 @@ fun <T : Any> BattleSelectionUiState<T>.isSelected(): Boolean = this is BattleSe
 
 fun <T : Any> BattleSelectionUiState<T>.selectedData(): T? = (this as? BattleSelectionUiState.Selected)?.selected
 
-fun <T : Any> BattleSelectionUiState<T>.hasSelectedChanged(): Boolean =
-    (this as? BattleSelectionUiState.Selected)?.hasSelectionChanged == true
+fun <T : Any> BattleSelectionUiState<T>.requireSelectedData(errorMessage: String): T {
+    return when (this) {
+        is BattleSelectionUiState.Selected -> selected
+        is BattleSelectionUiState.Empty -> throw IllegalArgumentException(errorMessage)
+    }
+}

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleViewModel.kt
@@ -27,7 +27,7 @@ import poke.rogue.helper.presentation.battle.model.toUi
 
 class BattleViewModel(
     private val battleRepository: BattleRepository,
-    logger: AnalyticsLogger = analyticsLogger(),
+    private val logger: AnalyticsLogger = analyticsLogger(),
 ) : ErrorHandleViewModel(logger), BattleNavigationHandler {
     private val _weathers = MutableStateFlow(emptyList<WeatherUiModel>())
     val weathers = _weathers.asStateFlow()
@@ -92,12 +92,18 @@ class BattleViewModel(
     fun updatePokemonSelection(selection: SelectionData) {
         when (selection) {
             is SelectionData.WithSkill ->
-                updateMyPokemon(
-                    selection.selectedPokemon,
-                    selection.selectedSkill,
-                )
+                {
+                    updateMyPokemon(
+                        selection.selectedPokemon,
+                        selection.selectedSkill,
+                    )
+                    logger.logPokemonSkillSelection(selection)
+                }
 
-            is SelectionData.WithoutSkill -> updateOpponentPokemon(selection.selectedPokemon)
+            is SelectionData.WithoutSkill -> {
+                updateOpponentPokemon(selection.selectedPokemon)
+                logger.logBattlePokemonSelection(selection)
+            }
             is SelectionData.NoSelection -> {}
         }
     }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleViewModel.kt
@@ -46,7 +46,11 @@ class BattleViewModel(
             } else {
                 BattleResultUiState.Idle
             }
-        }.stateIn(viewModelScope + errorHandler, SharingStarted.WhileSubscribed(5000), BattleResultUiState.Idle)
+        }.stateIn(
+            viewModelScope + errorHandler,
+            SharingStarted.WhileSubscribed(5000),
+            BattleResultUiState.Idle,
+        )
 
     val isBattleFetchSuccessful =
         battleResult.map { it.isSuccess() }
@@ -129,7 +133,8 @@ class BattleViewModel(
                 if (selectedPokemon == null) {
                     SelectionData.NoSelection
                 } else {
-                    previousSelection(selectionMode != SelectionMode.POKEMON_ONLY, selectedPokemon)
+                    val hasSkillSelection = selectionMode != SelectionMode.POKEMON_ONLY
+                    previousSelection(hasSkillSelection, selectedPokemon)
                 }
 
             val navigationData = SelectionNavigationData(selectionMode, data)
@@ -142,7 +147,8 @@ class BattleViewModel(
         previousPokemonSelection: PokemonSelectionUiModel,
     ): SelectionData {
         return if (hasSkillSelection) {
-            val skill = selectedState.value.skill.requireSelectedData("스킬이 선택되어야 합니다.")
+            val skill =
+                requireNotNull(selectedState.value.skill.selectedData()) { "스킬이 선택되어야 합니다." }
             SelectionData.WithSkill(previousPokemonSelection, skill)
         } else {
             SelectionData.WithoutSkill(previousPokemonSelection)

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SelectionData.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SelectionData.kt
@@ -19,7 +19,7 @@ sealed class SelectionData : Parcelable {
     data object NoSelection : SelectionData()
 }
 
-fun SelectionData.selectedPokemonOrNull(): PokemonSelectionUiModel? {
+fun SelectionData.selectedPokemon(): PokemonSelectionUiModel? {
     return when (this) {
         is SelectionData.NoSelection -> null
         is SelectionData.WithSkill -> this.selectedPokemon
@@ -27,7 +27,7 @@ fun SelectionData.selectedPokemonOrNull(): PokemonSelectionUiModel? {
     }
 }
 
-fun SelectionData.selectedSkillOrNull(): SkillSelectionUiModel? {
+fun SelectionData.selectedSkill(): SkillSelectionUiModel? {
     return when (this) {
         is SelectionData.NoSelection -> null
         is SelectionData.WithSkill -> this.selectedSkill

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SelectionData.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SelectionData.kt
@@ -16,11 +16,8 @@ sealed class SelectionData : Parcelable {
     ) : SelectionData()
 
     @Parcelize
-    data class NoSelection(val isSkillSelectionRequired: Boolean) : SelectionData()
+    data object NoSelection : SelectionData()
 }
-
-fun SelectionData.isSkillSelectionRequired(): Boolean =
-    this is SelectionData.WithSkill || (this as? SelectionData.NoSelection)?.isSkillSelectionRequired == true
 
 fun SelectionData.selectedPokemonOrNull(): PokemonSelectionUiModel? {
     return when (this) {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SelectionData.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SelectionData.kt
@@ -2,22 +2,8 @@ package poke.rogue.helper.presentation.battle.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
-import poke.rogue.helper.analytics.AnalyticsEvent
 import poke.rogue.helper.presentation.battle.model.SelectionData.WithSkill
 import poke.rogue.helper.presentation.battle.model.SelectionData.WithoutSkill
-
-fun WithSkill.toAnalyticsParams(): List<AnalyticsEvent.Param> {
-    return listOf(
-        AnalyticsEvent.Param(key = "pokemon_id", value = selectedPokemon.id),
-        AnalyticsEvent.Param(key = "skill_id", value = selectedSkill.id),
-    )
-}
-
-fun WithoutSkill.toAnalyticsParams(): List<AnalyticsEvent.Param> {
-    return listOf(
-        AnalyticsEvent.Param(key = "pokemon_id", value = selectedPokemon.id),
-    )
-}
 
 sealed class SelectionData : Parcelable {
     @Parcelize

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SelectionMode.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SelectionMode.kt
@@ -1,0 +1,9 @@
+package poke.rogue.helper.presentation.battle.model
+
+enum class SelectionMode {
+    POKEMON_ONLY,
+    POKEMON_AND_SKILL,
+    SKILL_FIRST,
+}
+
+fun SelectionMode.isSkillSelectionRequired(): Boolean = this != SelectionMode.POKEMON_ONLY

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SkillSelectionUiModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/SkillSelectionUiModel.kt
@@ -3,6 +3,7 @@ package poke.rogue.helper.presentation.battle.model
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import poke.rogue.helper.data.model.BattleSkill
+import poke.rogue.helper.presentation.dex.model.toUi
 import poke.rogue.helper.presentation.type.model.TypeUiModel
 import poke.rogue.helper.presentation.type.model.toUi
 
@@ -12,11 +13,7 @@ data class SkillSelectionUiModel(
     val name: String,
     val typeLogo: TypeUiModel,
     val categoryLogo: String,
-) : Parcelable {
-    companion object {
-        val DUMMY = listOf<SkillSelectionUiModel>()
-    }
-}
+) : Parcelable
 
 fun BattleSkill.toUi(): SkillSelectionUiModel =
     SkillSelectionUiModel(

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
@@ -59,9 +59,8 @@ class BattleSelectionActivity :
 
     @SuppressLint("ClickableViewAccessibility")
     private fun initListener() {
-        binding.root.setOnTouchListener { v, event ->
+        binding.root.setOnClickListener {
             hideKeyboard()
-            true
         }
     }
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
@@ -1,6 +1,5 @@
 package poke.rogue.helper.presentation.battle.selection
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -57,7 +56,6 @@ class BattleSelectionActivity :
         }
     }
 
-    @SuppressLint("ClickableViewAccessibility")
     private fun initListener() {
         binding.root.setOnClickListener {
             hideKeyboard()

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
@@ -1,5 +1,6 @@
 package poke.rogue.helper.presentation.battle.selection
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -11,6 +12,7 @@ import poke.rogue.helper.presentation.base.error.ErrorHandleActivity
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
 import poke.rogue.helper.presentation.battle.BattleSelectionUiState
 import poke.rogue.helper.presentation.battle.model.SelectionData
+import poke.rogue.helper.presentation.util.activity.hideKeyboard
 import poke.rogue.helper.presentation.util.parcelable
 import poke.rogue.helper.presentation.util.repeatOnStarted
 import poke.rogue.helper.presentation.util.view.setImage
@@ -36,14 +38,26 @@ class BattleSelectionActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initViews()
+        initListener()
         initObserver()
     }
 
     private fun initViews() {
         binding.lifecycleOwner = this
         binding.vm = viewModel
-        binding.pagerBattleSelection.adapter = selectionPagerAdapter
-        binding.pagerBattleSelection.isUserInputEnabled = false
+
+        with(binding.pagerBattleSelection) {
+            adapter = selectionPagerAdapter
+            isUserInputEnabled = false
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun initListener() {
+        binding.root.setOnTouchListener { v, event ->
+            hideKeyboard()
+            true
+        }
     }
 
     private fun initObserver() {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
@@ -69,7 +69,7 @@ class BattleSelectionActivity :
         repeatOnStarted {
             viewModel.selectedPokemon.collect { selectionState ->
                 if (selectionState is BattleSelectionUiState.Selected) {
-                    val selected = selectionState.selected
+                    val selected = selectionState.content
                     binding.ivPokemon.setImage(selected.frontImageUrl)
                     binding.toolbarBattleSelection.title = selected.name
                 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionActivity.kt
@@ -12,18 +12,23 @@ import poke.rogue.helper.presentation.base.error.ErrorHandleActivity
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
 import poke.rogue.helper.presentation.battle.BattleSelectionUiState
 import poke.rogue.helper.presentation.battle.model.SelectionData
+import poke.rogue.helper.presentation.battle.model.SelectionMode
 import poke.rogue.helper.presentation.util.activity.hideKeyboard
 import poke.rogue.helper.presentation.util.parcelable
 import poke.rogue.helper.presentation.util.repeatOnStarted
+import poke.rogue.helper.presentation.util.serializable
 import poke.rogue.helper.presentation.util.view.setImage
 
 class BattleSelectionActivity :
     ErrorHandleActivity<ActivityBattleSelectionBinding>(R.layout.activity_battle_selection) {
     private val viewModel by viewModels<BattleSelectionViewModel> {
-        BattleSelectionViewModel.factory(previousSelection)
+        BattleSelectionViewModel.factory(selectionMode, previousSelection)
     }
     private val previousSelection by lazy {
-        intent.parcelable<SelectionData>(KEY_PREVIOUS_SELECTION) ?: throw IllegalArgumentException("잘못된 선택 데이터")
+        intent.parcelable<SelectionData>(KEY_PREVIOUS_SELECTION) ?: error("잘못된 선택 데이터")
+    }
+    private val selectionMode by lazy {
+        intent.serializable<SelectionMode>(KEY_SELECTION_MODE) ?: error("잘못된 선택 데이터")
     }
     private val selectionPagerAdapter: BattleSelectionPagerAdapter by lazy {
         BattleSelectionPagerAdapter(this)
@@ -91,14 +96,17 @@ class BattleSelectionActivity :
     }
 
     companion object {
+        private const val KEY_SELECTION_MODE = "selectionMode"
         private const val KEY_PREVIOUS_SELECTION = "previousSelection"
         const val KEY_SELECTION_RESULT = "selectionResult"
 
         fun intent(
             context: Context,
+            selectionMode: SelectionMode,
             previousSelection: SelectionData,
         ): Intent =
             Intent(context, BattleSelectionActivity::class.java).apply {
+                putExtra(KEY_SELECTION_MODE, selectionMode)
                 putExtra(KEY_PREVIOUS_SELECTION, previousSelection)
             }
     }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/BattleSelectionViewModel.kt
@@ -86,12 +86,13 @@ class BattleSelectionViewModel(
     }
 
     fun selectPokemon(pokemon: PokemonSelectionUiModel) {
-        _selectedPokemon.value = BattleSelectionUiState.Selected(pokemon)
+        _selectedPokemon.value =
+            BattleSelectionUiState.Selected(pokemon, hasSelectionChanged = true)
         _selectedSkill.value = BattleSelectionUiState.Empty
     }
 
     fun selectSkill(skill: SkillSelectionUiModel) {
-        _selectedSkill.value = BattleSelectionUiState.Selected(skill)
+        _selectedSkill.value = BattleSelectionUiState.Selected(skill, hasSelectionChanged = true)
     }
 
     override fun navigateToNextPage() {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/SelectionStep.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/SelectionStep.kt
@@ -5,7 +5,7 @@ enum class SelectionStep {
     SKILL_SELECTION,
     ;
 
-    fun hasPreviousStep(): Boolean = this.ordinal > 0
+    fun isFirstStep(): Boolean = this.ordinal > 0
 
     fun isLastStep(hasSkillSelection: Boolean): Boolean {
         return if (hasSkillSelection) {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/BattlePokemonTypesAdapter.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/BattlePokemonTypesAdapter.kt
@@ -1,0 +1,39 @@
+package poke.rogue.helper.presentation.battle.selection.pokemon
+
+import android.content.Context
+import android.widget.ImageView
+import com.google.android.flexbox.FlexboxLayout
+import poke.rogue.helper.presentation.type.model.TypeUiModel
+import poke.rogue.helper.presentation.util.view.dp
+
+class BattlePokemonTypesAdapter(private val context: Context, private val viewGroup: FlexboxLayout) {
+    fun addTypes(
+        types: List<TypeUiModel>,
+        spacingBetweenTypes: Int = 0.dp,
+        iconSize: Int = 18.dp,
+    ) {
+        viewGroup.removeAllViews()
+
+        types.forEach { type ->
+            val imageView =
+                ImageView(context).apply {
+                    setImageResource(type.typeIconResId)
+
+                    layoutParams =
+                        FlexboxLayout.LayoutParams(
+                            iconSize,
+                            iconSize,
+                        ).apply {
+                            setMargins(
+                                spacingBetweenTypes,
+                                0,
+                                0,
+                                0,
+                            )
+                        }
+                }
+
+            viewGroup.addView(imageView)
+        }
+    }
+}

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionFragment.kt
@@ -1,5 +1,6 @@
 package poke.rogue.helper.presentation.battle.selection.pokemon
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
@@ -12,9 +13,12 @@ import poke.rogue.helper.presentation.base.error.ErrorHandleFragment
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
 import poke.rogue.helper.presentation.battle.model.selectedPokemonOrNull
 import poke.rogue.helper.presentation.battle.selection.BattleSelectionViewModel
+import poke.rogue.helper.presentation.util.activity.hideKeyboard
+import poke.rogue.helper.presentation.util.fragment.hideKeyboard
 import poke.rogue.helper.presentation.util.repeatOnStarted
 import poke.rogue.helper.presentation.util.view.LinearSpacingItemDecoration
 import poke.rogue.helper.presentation.util.view.dp
+import poke.rogue.helper.presentation.util.view.setOnSearchAction
 
 class PokemonSelectionFragment :
     ErrorHandleFragment<FragmentPokemonSelectionBinding>(R.layout.fragment_pokemon_selection) {
@@ -40,6 +44,7 @@ class PokemonSelectionFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
         initViews()
+        initListener()
         initObserver()
     }
 
@@ -55,6 +60,16 @@ class PokemonSelectionFragment :
         }
     }
 
+    @SuppressLint("ClickableViewAccessibility")
+    private fun initListener() {
+        binding.rvPokemons.setOnTouchListener { _, _ ->
+            hideKeyboard()
+            false
+        }
+
+        binding.etPokemonSelectionSearch.setOnSearchAction { hideKeyboard() }
+    }
+
     private fun initObserver() {
         repeatOnStarted {
             viewModel.filteredPokemon.collect {
@@ -64,6 +79,7 @@ class PokemonSelectionFragment :
 
         repeatOnStarted {
             viewModel.pokemonSelectedEvent.collect {
+                requireActivity().hideKeyboard()
                 sharedViewModel.selectPokemon(it)
             }
         }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionFragment.kt
@@ -79,7 +79,7 @@ class PokemonSelectionFragment :
 
         repeatOnStarted {
             viewModel.pokemonSelectedEvent.collect {
-                requireActivity().hideKeyboard()
+                hideKeyboard()
                 sharedViewModel.selectPokemon(it)
             }
         }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionFragment.kt
@@ -11,9 +11,8 @@ import poke.rogue.helper.data.repository.DefaultDexRepository
 import poke.rogue.helper.databinding.FragmentPokemonSelectionBinding
 import poke.rogue.helper.presentation.base.error.ErrorHandleFragment
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
-import poke.rogue.helper.presentation.battle.model.selectedPokemonOrNull
+import poke.rogue.helper.presentation.battle.model.selectedPokemon
 import poke.rogue.helper.presentation.battle.selection.BattleSelectionViewModel
-import poke.rogue.helper.presentation.util.activity.hideKeyboard
 import poke.rogue.helper.presentation.util.fragment.hideKeyboard
 import poke.rogue.helper.presentation.util.repeatOnStarted
 import poke.rogue.helper.presentation.util.view.LinearSpacingItemDecoration
@@ -26,7 +25,7 @@ class PokemonSelectionFragment :
     private val viewModel: PokemonSelectionViewModel by viewModels<PokemonSelectionViewModel> {
         PokemonSelectionViewModel.factory(
             DefaultDexRepository.instance(),
-            sharedViewModel.previousSelection.selectedPokemonOrNull(),
+            sharedViewModel.previousSelection.selectedPokemon(),
         )
     }
     private val pokemonAdapter: PokemonSelectionAdapter by lazy {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionViewHolder.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionViewHolder.kt
@@ -3,7 +3,6 @@ package poke.rogue.helper.presentation.battle.selection.pokemon
 import androidx.recyclerview.widget.RecyclerView
 import poke.rogue.helper.databinding.ItemBattlePokemonSelectionBinding
 import poke.rogue.helper.presentation.battle.model.PokemonSelectionUiModel
-import poke.rogue.helper.presentation.biome.BiomeTypesAdapter
 import poke.rogue.helper.presentation.util.view.dp
 
 class PokemonSelectionViewHolder(
@@ -18,7 +17,7 @@ class PokemonSelectionViewHolder(
         binding.isSelected = isSelected
         binding.selectionHandler = selectionHandler
 
-        val typeAdapter = BiomeTypesAdapter(context = binding.root.context, binding.flexboxTypes)
+        val typeAdapter = BattlePokemonTypesAdapter(context = binding.root.context, binding.flexboxTypes)
         typeAdapter.addTypes(
             types = pokemonSelectionUiModel.types,
             spacingBetweenTypes = 8.dp,

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import kotlinx.coroutines.flow.collectLatest
 import poke.rogue.helper.R
 import poke.rogue.helper.data.repository.DefaultBattleRepository
 import poke.rogue.helper.databinding.FragmentSkillSelectionBinding
@@ -80,7 +79,7 @@ class SkillSelectionFragment :
         }
 
         repeatOnStarted {
-            viewModel.filteredSkills.collectLatest {
+            viewModel.filteredSkills.collect {
                 skillAdapter.submitList(it)
             }
         }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -12,9 +12,7 @@ import poke.rogue.helper.data.repository.DefaultBattleRepository
 import poke.rogue.helper.databinding.FragmentSkillSelectionBinding
 import poke.rogue.helper.presentation.base.error.ErrorHandleFragment
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
-import poke.rogue.helper.presentation.battle.hasSelectedChanged
 import poke.rogue.helper.presentation.battle.model.SelectionData
-import poke.rogue.helper.presentation.battle.selectedData
 import poke.rogue.helper.presentation.battle.selection.BattleSelectionViewModel
 import poke.rogue.helper.presentation.util.fragment.hideKeyboard
 import poke.rogue.helper.presentation.util.repeatOnStarted
@@ -72,16 +70,17 @@ class SkillSelectionFragment :
 
     private fun initObserver() {
         repeatOnStarted {
-            sharedViewModel.selectedPokemon.collectLatest {
-                val dexNumber = it.selectedData()?.dexNumber
-                if (dexNumber != null && it.hasSelectedChanged()) {
-                    viewModel.updateSkills(dexNumber)
+            sharedViewModel.pokemonSelectionUpdate.collect { newDexNumber ->
+                if (newDexNumber != viewModel.previousPokemonDexNumber) {
+                    viewModel.updateSkills(newDexNumber)
+                } else {
+                    viewModel.updatePreviousSkills(newDexNumber)
                 }
             }
         }
 
         repeatOnStarted {
-            viewModel.filteredSkills.collect {
+            viewModel.filteredSkills.collectLatest {
                 skillAdapter.submitList(it)
             }
         }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -1,5 +1,6 @@
 package poke.rogue.helper.presentation.battle.selection.skill
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
@@ -14,9 +15,11 @@ import poke.rogue.helper.presentation.battle.model.SelectionData
 import poke.rogue.helper.presentation.battle.model.selectedPokemonOrNull
 import poke.rogue.helper.presentation.battle.selectedData
 import poke.rogue.helper.presentation.battle.selection.BattleSelectionViewModel
+import poke.rogue.helper.presentation.util.fragment.hideKeyboard
 import poke.rogue.helper.presentation.util.repeatOnStarted
 import poke.rogue.helper.presentation.util.view.LinearSpacingItemDecoration
 import poke.rogue.helper.presentation.util.view.dp
+import poke.rogue.helper.presentation.util.view.setOnSearchAction
 
 class SkillSelectionFragment :
     ErrorHandleFragment<FragmentSkillSelectionBinding>(R.layout.fragment_skill_selection) {
@@ -42,6 +45,7 @@ class SkillSelectionFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
         initViews()
+        initListener()
         initObserver()
     }
 
@@ -54,6 +58,16 @@ class SkillSelectionFragment :
         }
         binding.handler = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun initListener() {
+        binding.rvSkills.setOnTouchListener { _, _ ->
+            hideKeyboard()
+            false
+        }
+
+        binding.etSkillSelectionSearch.setOnSearchAction { hideKeyboard() }
     }
 
     private fun initObserver() {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -6,13 +6,14 @@ import android.view.View
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import kotlinx.coroutines.flow.collectLatest
 import poke.rogue.helper.R
 import poke.rogue.helper.data.repository.DefaultBattleRepository
 import poke.rogue.helper.databinding.FragmentSkillSelectionBinding
 import poke.rogue.helper.presentation.base.error.ErrorHandleFragment
 import poke.rogue.helper.presentation.base.error.ErrorHandleViewModel
+import poke.rogue.helper.presentation.battle.hasSelectedChanged
 import poke.rogue.helper.presentation.battle.model.SelectionData
-import poke.rogue.helper.presentation.battle.model.selectedPokemonOrNull
 import poke.rogue.helper.presentation.battle.selectedData
 import poke.rogue.helper.presentation.battle.selection.BattleSelectionViewModel
 import poke.rogue.helper.presentation.util.fragment.hideKeyboard
@@ -66,19 +67,14 @@ class SkillSelectionFragment :
             hideKeyboard()
             false
         }
-
         binding.etSkillSelectionSearch.setOnSearchAction { hideKeyboard() }
     }
 
     private fun initObserver() {
         repeatOnStarted {
-            sharedViewModel.selectedPokemon.collect {
+            sharedViewModel.selectedPokemon.collectLatest {
                 val dexNumber = it.selectedData()?.dexNumber
-                val selectedPokemonId = it.selectedData()?.id
-                val previousSelectedPokemonId =
-                    sharedViewModel.previousSelection.selectedPokemonOrNull()?.id
-
-                if (dexNumber != null && previousSelectedPokemonId != selectedPokemonId) {
+                if (dexNumber != null && it.hasSelectedChanged()) {
                     viewModel.updateSkills(dexNumber)
                 }
             }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -87,6 +87,7 @@ class SkillSelectionFragment :
 
         repeatOnStarted {
             viewModel.skillSelectedEvent.collect {
+                hideKeyboard()
                 sharedViewModel.selectSkill(it)
             }
         }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionViewModel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import poke.rogue.helper.analytics.AnalyticsLogger
@@ -48,7 +48,7 @@ class SkillSelectionViewModel(
         searchQuery
             .debounce(300L)
             .flatMapLatest { query ->
-                skills.map { skillsList ->
+                skills.mapLatest { skillsList ->
                     if (query.isBlank()) {
                         skillsList
                     } else {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionViewModel.kt
@@ -25,8 +25,8 @@ import poke.rogue.helper.presentation.battle.model.SkillSelectionUiModel
 import poke.rogue.helper.presentation.battle.model.toUi
 import poke.rogue.helper.presentation.battle.selection.QueryHandler
 import poke.rogue.helper.presentation.dex.filter.SelectableUiModel
+import poke.rogue.helper.presentation.dex.filter.initialized
 import poke.rogue.helper.presentation.dex.filter.toSelectableModelsBy
-import poke.rogue.helper.presentation.dex.filter.toSelectableModelsWithAllDeselected
 import poke.rogue.helper.stringmatcher.has
 
 class SkillSelectionViewModel(
@@ -79,9 +79,8 @@ class SkillSelectionViewModel(
         previousPokemonDexNumber = pokemonDexNumber
         viewModelScope.launch(errorHandler) {
             _skills.value = emptyList()
-            val availableSkills =
-                battleRepository.availableSkills(pokemonDexNumber).map { it.toUi() }
-            _skills.value = availableSkills.toSelectableModelsWithAllDeselected()
+            val availableSkills = battleRepository.availableSkills(pokemonDexNumber).map { it.toUi() }
+            _skills.value = availableSkills.initialized()
         }
     }
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/dex/filter/SelectableUiModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/dex/filter/SelectableUiModel.kt
@@ -10,15 +10,8 @@ data class SelectableUiModel<T : Parcelable>(
     val data: T,
 ) : Parcelable
 
-fun <T : Parcelable> List<T>.toSelectableModelsWithAllDeselected(): List<SelectableUiModel<T>> {
+fun <T : Parcelable> List<T>.initialized(): List<SelectableUiModel<T>> {
     return this.mapIndexed { index, t -> SelectableUiModel(index, false, t) }
-}
-
-fun <T : Parcelable> List<SelectableUiModel<T>>.updateSelectionBy(predicate: (T) -> Boolean): List<SelectableUiModel<T>> {
-    return this.map {
-        val isSelected = predicate(it.data)
-        it.copy(isSelected = isSelected)
-    }
 }
 
 fun <T : Parcelable> List<T>.toSelectableModelsBy(predicate: (T) -> Boolean): List<SelectableUiModel<T>> {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/fragment/FragmentExtension.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/fragment/FragmentExtension.kt
@@ -91,5 +91,7 @@ inline fun <reified T : Activity> Fragment.startActivity(argusBuilder: Intent.()
 
 fun Fragment.hideKeyboard() {
     val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    imm.hideSoftInputFromWindow(requireView().windowToken, 0)
+    if (imm.isAcceptingText) {
+        imm.hideSoftInputFromWindow(requireView().windowToken, 0)
+    }
 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/fragment/FragmentExtension.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/fragment/FragmentExtension.kt
@@ -1,9 +1,11 @@
 package poke.rogue.helper.presentation.util.fragment
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
@@ -85,4 +87,9 @@ val Fragment.viewLifeCycleScope
 
 inline fun <reified T : Activity> Fragment.startActivity(argusBuilder: Intent.() -> Unit = {}) {
     startActivity(Intent(requireContext(), T::class.java).apply(argusBuilder))
+}
+
+fun Fragment.hideKeyboard() {
+    val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    imm.hideSoftInputFromWindow(requireView().windowToken, 0)
 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/view/ViewExtension.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/view/ViewExtension.kt
@@ -1,0 +1,13 @@
+package poke.rogue.helper.presentation.util.view
+
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+
+fun EditText.setOnSearchAction(action: () -> Unit) {
+    setOnEditorActionListener { _, actionId, _ ->
+        if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+            action()
+        }
+        true
+    }
+}

--- a/android/app/src/main/res/layout/activity_battle.xml
+++ b/android/app/src/main/res/layout/activity_battle.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <import type="poke.rogue.helper.presentation.battle.model.SelectionMode"/>
 
         <variable
             name="vm"
@@ -111,7 +112,7 @@
 
         <ImageView
             android:id="@+id/iv_opponent_pokemon"
-            onSingleClick="@{() -> vm.navigateToSelection(false)}"
+            onSingleClick="@{() -> vm.navigateToSelection(SelectionMode.POKEMON_ONLY)}"
             android:layout_width="140dp"
             android:layout_height="wrap_content"
             android:src="@drawable/icon_pokemon_selection_op"
@@ -144,7 +145,7 @@
 
         <ImageView
             android:id="@+id/iv_mine_pokemon"
-            onSingleClick="@{() -> vm.navigateToSelection(true)}"
+            onSingleClick="@{() -> vm.navigateToSelection(SelectionMode.POKEMON_AND_SKILL)}"
             android:layout_width="140dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="-12dp"
@@ -155,7 +156,7 @@
 
         <TextView
             android:id="@+id/tv_skill_title"
-            onSingleClick="@{() -> vm.navigateToSelection(true)}"
+            onSingleClick="@{() -> vm.navigateToSelection(SelectionMode.SKILL_FIRST)}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="@drawable/bg_battle_default"

--- a/android/app/src/main/res/layout/activity_battle.xml
+++ b/android/app/src/main/res/layout/activity_battle.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-        <import type="poke.rogue.helper.presentation.battle.model.SelectionMode"/>
+
+        <import type="poke.rogue.helper.presentation.battle.model.SelectionMode" />
 
         <variable
             name="vm"
@@ -54,14 +55,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            app:layout_constraintGuide_percent="0.68" />
+            app:layout_constraintGuide_percent="0.7" />
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/gl_bottom"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            app:layout_constraintGuide_end="40dp" />
+            app:layout_constraintGuide_end="20dp" />
 
         <Spinner
             android:id="@+id/spinner_weather"
@@ -78,12 +79,12 @@
 
         <TextView
             android:id="@+id/tv_weather_description"
-            style="@style/TextAppearance.Poke.Description"
+            style="@style/TextAppearance.Poke.CaptionLarge"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
-            android:textStyle="italic"
             android:gravity="end"
+            android:textStyle="italic"
             app:layout_constraintEnd_toEndOf="@id/spinner_weather"
             app:layout_constraintStart_toStartOf="@id/spinner_weather"
             app:layout_constraintTop_toBottomOf="@id/spinner_weather" />
@@ -113,10 +114,10 @@
         <ImageView
             android:id="@+id/iv_opponent_pokemon"
             onSingleClick="@{() -> vm.navigateToSelection(SelectionMode.POKEMON_ONLY)}"
-            android:layout_width="140dp"
+            android:layout_width="120dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
             android:src="@drawable/icon_pokemon_selection_op"
-            app:layout_constraintBottom_toTopOf="@id/iv_mine_pokemon"
             app:layout_constraintEnd_toEndOf="@id/gl_end"
             app:layout_constraintTop_toBottomOf="@id/tv_weather_description" />
 
@@ -146,9 +147,10 @@
         <ImageView
             android:id="@+id/iv_mine_pokemon"
             onSingleClick="@{() -> vm.navigateToSelection(SelectionMode.POKEMON_AND_SKILL)}"
-            android:layout_width="140dp"
+            android:layout_width="120dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="-12dp"
+            android:layout_marginTop="-24dp"
+            android:layout_marginBottom="12dp"
             android:src="@drawable/icon_pokemon_selection_mine"
             app:layout_constraintBottom_toTopOf="@id/gl_divider"
             app:layout_constraintStart_toStartOf="@id/gl_start"
@@ -188,12 +190,12 @@
             visible="@{vm.isBattleFetchSuccessful}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/battle_power_title"
             android:layout_marginTop="20dp"
-            app:layout_constraintHorizontal_chainStyle="spread"
+            android:text="@string/battle_power_title"
             app:layout_constraintEnd_toStartOf="@id/tv_multiplier"
+            app:layout_constraintHorizontal_chainStyle="spread"
             app:layout_constraintStart_toStartOf="@id/gl_start"
-            app:layout_constraintTop_toBottomOf="@id/tv_result_title"/>
+            app:layout_constraintTop_toBottomOf="@id/tv_result_title" />
 
         <TextView
             android:id="@+id/tv_power_content"
@@ -205,7 +207,7 @@
             app:layout_constraintEnd_toEndOf="@id/tv_power_title"
             app:layout_constraintStart_toStartOf="@id/tv_power_title"
             app:layout_constraintTop_toBottomOf="@id/tv_power_title"
-            tools:text="30"/>
+            tools:text="30" />
 
         <TextView
             android:id="@+id/tv_multiplier"
@@ -213,12 +215,12 @@
             visible="@{vm.isBattleFetchSuccessful}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/battle_result_multiplier"
             android:gravity="center_vertical"
+            android:text="@string/battle_result_multiplier"
+            app:layout_constraintBottom_toBottomOf="@id/tv_power_title"
             app:layout_constraintEnd_toStartOf="@id/tv_multiplier_title"
             app:layout_constraintStart_toEndOf="@id/tv_power_title"
-            app:layout_constraintTop_toTopOf="@id/tv_power_title"
-            app:layout_constraintBottom_toBottomOf="@id/tv_power_title"/>
+            app:layout_constraintTop_toTopOf="@id/tv_power_title" />
 
         <TextView
             android:id="@+id/tv_multiplier_title"
@@ -227,8 +229,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/battle_multiplier_title"
-            app:layout_constraintEnd_toStartOf="@id/tv_equal"
             app:layout_constraintBottom_toBottomOf="@id/tv_power_title"
+            app:layout_constraintEnd_toStartOf="@id/tv_equal"
             app:layout_constraintStart_toEndOf="@id/tv_multiplier"
             app:layout_constraintTop_toTopOf="@id/tv_power_title" />
 
@@ -251,10 +253,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/battle_result_equal"
-            app:layout_constraintEnd_toStartOf="@id/tv_calculated_power_title"
             app:layout_constraintBottom_toBottomOf="@id/tv_power_title"
+            app:layout_constraintEnd_toStartOf="@id/tv_calculated_power_title"
             app:layout_constraintStart_toEndOf="@id/tv_multiplier_title"
-            app:layout_constraintTop_toTopOf="@id/tv_power_title"/>
+            app:layout_constraintTop_toTopOf="@id/tv_power_title" />
 
         <TextView
             android:id="@+id/tv_calculated_power_title"
@@ -263,9 +265,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/battle_calculated_power_title"
+            app:layout_constraintBottom_toBottomOf="@id/tv_power_title"
             app:layout_constraintEnd_toEndOf="@id/gl_end"
             app:layout_constraintStart_toEndOf="@id/tv_equal"
-            app:layout_constraintBottom_toBottomOf="@id/tv_power_title"
             app:layout_constraintTop_toTopOf="@id/tv_power_title" />
 
         <TextView
@@ -278,7 +280,7 @@
             app:layout_constraintEnd_toEndOf="@id/tv_calculated_power_title"
             app:layout_constraintStart_toStartOf="@id/tv_calculated_power_title"
             app:layout_constraintTop_toBottomOf="@id/tv_calculated_power_title"
-            tools:text="30"/>
+            tools:text="30" />
 
         <TextView
             android:id="@+id/tv_accuracy_content"
@@ -287,11 +289,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/battle_accuracy_title"
-            app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintBottom_toBottomOf="@id/gl_bottom"
-            app:layout_constraintStart_toStartOf="@id/tv_calculated_power_content"
             app:layout_constraintEnd_toEndOf="@id/tv_calculated_power_content"
-            app:layout_constraintTop_toBottomOf="@id/tv_calculated_power_content"/>
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="@id/tv_calculated_power_content"
+            app:layout_constraintTop_toBottomOf="@id/tv_calculated_power_content" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/activity_battle_selection.xml
+++ b/android/app/src/main/res/layout/activity_battle_selection.xml
@@ -88,7 +88,7 @@
             android:id="@+id/btn_prev"
             style="@style/TextAppearance.Poke.TitleBold"
             onSingleClick="@{() -> vm.navigateToPrevPage()}"
-            visible="@{vm.currentStep.hasPreviousStep()}"
+            visible="@{vm.currentStep.isFirstStep()}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"

--- a/android/app/src/main/res/layout/activity_battle_selection.xml
+++ b/android/app/src/main/res/layout/activity_battle_selection.xml
@@ -11,7 +11,6 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/main"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".presentation.battle.selection.BattleSelectionActivity">

--- a/android/app/src/main/res/layout/fragment_skill_selection.xml
+++ b/android/app/src/main/res/layout/fragment_skill_selection.xml
@@ -30,7 +30,7 @@
             app:layout_constraintGuide_end="20dp" />
 
         <EditText
-            android:id="@+id/et_pokemon_selection_search"
+            android:id="@+id/et_skill_selection_search"
             onTextChanged="@{handler}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -52,9 +52,9 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="12dp"
             android:src="@drawable/icon_search"
-            app:layout_constraintBottom_toBottomOf="@id/et_pokemon_selection_search"
-            app:layout_constraintEnd_toEndOf="@id/et_pokemon_selection_search"
-            app:layout_constraintTop_toTopOf="@id/et_pokemon_selection_search" />
+            app:layout_constraintBottom_toBottomOf="@id/et_skill_selection_search"
+            app:layout_constraintEnd_toEndOf="@id/et_skill_selection_search"
+            app:layout_constraintTop_toTopOf="@id/et_skill_selection_search" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_skills"
@@ -66,7 +66,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/gl_end"
             app:layout_constraintStart_toStartOf="@id/gl_start"
-            app:layout_constraintTop_toBottomOf="@id/et_pokemon_selection_search"
+            app:layout_constraintTop_toBottomOf="@id/et_skill_selection_search"
             tools:listitem="@layout/item_battle_pokemon_selection" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- closed #297
## 작업 영상
https://github.com/user-attachments/assets/4481e44d-5f8b-479f-92dc-87f8cf7839e8


## 작업한 내용
생각보다,,, 변수가 많아서 조금 걸렸네용 🥹 

✅ 다른 영역 터치 시  키보드 내리기
 -> 버튼 올리기 제외

✅ 포켓몬에 해당 하는 기술 불러오는 부분 오류 해결 
   -> 이전에 선택했던 포켓몬 데이터를 불러오는 과정에서 꼬였었더라구요

✅ `기술` 선택 시 바로 `기술 선택` 페이지로 이동
  -> 만약 선택된 데이터가 없는 경우에는 바로 포켓몬 선택으로 이동
  -> 선택된 데이터가 있다면 바로 기술 선택으로!

✅ `registerForActivityResult` 로 리팩토링!
 -> 액티비티 버전 문제가 해결되어서 다시 리팩토링 했습니당

살짝씩 깜빡거리는 부분이 있는것 같기는 한데 이런 부분들은 차차 개선해보도록 하겠습니당

## 🚀Next Feature
- 로그 달기
- 기술 위력 정보 UI 개선