### PR TITLE
[1.1.0/AN-FEAT] 배틀 선택 / 결과 UI 개선 

### DIFF
--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleActivity.kt
@@ -15,6 +15,7 @@ import poke.rogue.helper.presentation.base.toolbar.ToolbarActivity
 import poke.rogue.helper.presentation.battle.model.SelectionData
 import poke.rogue.helper.presentation.battle.model.WeatherUiModel
 import poke.rogue.helper.presentation.battle.selection.BattleSelectionActivity
+import poke.rogue.helper.presentation.util.context.colorOf
 import poke.rogue.helper.presentation.util.parcelable
 import poke.rogue.helper.presentation.util.repeatOnStarted
 import poke.rogue.helper.presentation.util.view.setImage
@@ -123,6 +124,7 @@ class BattleActivity : ToolbarActivity<ActivityBattleBinding>(R.layout.activity_
                     val result = it.result
                     binding.tvPowerContent.text = result.power
                     binding.tvMultiplierContent.text = result.multiplier
+                    binding.tvMultiplierContent.setTextColor(colorOf(result.colorRes))
                     binding.tvCalculatedPowerContent.text = result.calculatedResult
                     binding.tvAccuracyContent.text =
                         getString(R.string.battle_accuracy_title, result.accuracy)

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
@@ -21,21 +21,26 @@ data class BattlePredictionUiModel(
 
 fun BattlePrediction.toUi(format: String = DEFAULT_NUMBER_FORMAT): BattlePredictionUiModel {
     val formattedPower = if (power < 0) NO_EFFECT_VALUE else power.toString()
-    val formattedResult = if (calculatedResult < 0) NO_EFFECT_VALUE else String.format(format, calculatedResult)
     val formattedAccuracy = if (accuracy < 0) NO_EFFECT_VALUE else String.format(format, accuracy)
-    val color =
-        when {
-            multiplier < 1.0 -> R.color.poke_grey_60
-            multiplier in 1.0..2.9 -> R.color.poke_red_20
-            multiplier >= 3 -> R.color.poke_green_20
-            else -> R.color.poke_white
-        }
+    val formattedMultiplier = if (power < 0) NO_EFFECT_VALUE else String.format(format, multiplier)
+    val formattedResult =
+        if (calculatedResult < 0) NO_EFFECT_VALUE else String.format(format, calculatedResult)
+
+    val color = selectedColorResource(multiplier)
 
     return BattlePredictionUiModel(
         power = formattedPower,
         accuracy = formattedAccuracy,
-        multiplier = String.format(format, multiplier),
+        multiplier = formattedMultiplier,
         calculatedResult = formattedResult,
         colorRes = color,
     )
 }
+
+private fun selectedColorResource(value: Double): Int =
+    when {
+        value < 1.0 -> R.color.poke_grey_60
+        value in 1.0..2.9 -> R.color.poke_red_20
+        value >= 3 -> R.color.poke_green_20
+        else -> R.color.poke_white
+    }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
@@ -1,13 +1,22 @@
 package poke.rogue.helper.presentation.battle.model
 
 import poke.rogue.helper.data.model.BattlePrediction
+import poke.rogue.helper.presentation.battle.model.BattlePredictionUiModel.Companion.NO_EFFECT_VALUE
 
-data class BattlePredictionUiModel(val power: String, val accuracy: String, val multiplier: String, val calculatedResult: String)
+data class BattlePredictionUiModel(val power: String, val accuracy: String, val multiplier: String, val calculatedResult: String) {
+    companion object {
+        const val NO_EFFECT_VALUE = "-"
+    }
+}
 
-fun BattlePrediction.toUi(format: String = "%.1f"): BattlePredictionUiModel =
-    BattlePredictionUiModel(
-        power = power.toString(),
+fun BattlePrediction.toUi(format: String = "%.1f"): BattlePredictionUiModel {
+    val formattedPower = if (power < 0) NO_EFFECT_VALUE else power.toString()
+    val formattedResult = if (calculatedResult < 0) NO_EFFECT_VALUE else String.format(format, calculatedResult)
+
+    return BattlePredictionUiModel(
+        power = formattedPower,
         accuracy = String.format(format, accuracy),
         multiplier = String.format(format, multiplier),
-        calculatedResult = String.format(format, calculatedResult),
+        calculatedResult = formattedResult,
     )
+}

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
@@ -1,22 +1,40 @@
 package poke.rogue.helper.presentation.battle.model
 
+import androidx.annotation.ColorRes
+import poke.rogue.helper.R
 import poke.rogue.helper.data.model.BattlePrediction
+import poke.rogue.helper.presentation.battle.model.BattlePredictionUiModel.Companion.DEFAULT_NUMBER_FORMAT
 import poke.rogue.helper.presentation.battle.model.BattlePredictionUiModel.Companion.NO_EFFECT_VALUE
 
-data class BattlePredictionUiModel(val power: String, val accuracy: String, val multiplier: String, val calculatedResult: String) {
+data class BattlePredictionUiModel(
+    val power: String,
+    val accuracy: String,
+    val multiplier: String,
+    val calculatedResult: String,
+    @ColorRes val colorRes: Int,
+) {
     companion object {
         const val NO_EFFECT_VALUE = "-"
+        const val DEFAULT_NUMBER_FORMAT = "%.1f"
     }
 }
 
-fun BattlePrediction.toUi(format: String = "%.1f"): BattlePredictionUiModel {
+fun BattlePrediction.toUi(format: String = DEFAULT_NUMBER_FORMAT): BattlePredictionUiModel {
     val formattedPower = if (power < 0) NO_EFFECT_VALUE else power.toString()
     val formattedResult = if (calculatedResult < 0) NO_EFFECT_VALUE else String.format(format, calculatedResult)
+    val color =
+        when {
+            multiplier < 1.0 -> R.color.poke_grey_65
+            multiplier in 1.0..2.9 -> R.color.poke_red_20
+            multiplier >= 3 -> R.color.poke_green_20
+            else -> R.color.poke_white
+        }
 
     return BattlePredictionUiModel(
         power = formattedPower,
         accuracy = String.format(format, accuracy),
         multiplier = String.format(format, multiplier),
         calculatedResult = formattedResult,
+        colorRes = color,
     )
 }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
@@ -24,7 +24,7 @@ fun BattlePrediction.toUi(format: String = DEFAULT_NUMBER_FORMAT): BattlePredict
     val formattedResult = if (calculatedResult < 0) NO_EFFECT_VALUE else String.format(format, calculatedResult)
     val color =
         when {
-            multiplier < 1.0 -> R.color.poke_grey_65
+            multiplier < 1.0 -> R.color.poke_grey_60
             multiplier in 1.0..2.9 -> R.color.poke_red_20
             multiplier >= 3 -> R.color.poke_green_20
             else -> R.color.poke_white

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/model/BattlePredictionUiModel.kt
@@ -22,6 +22,7 @@ data class BattlePredictionUiModel(
 fun BattlePrediction.toUi(format: String = DEFAULT_NUMBER_FORMAT): BattlePredictionUiModel {
     val formattedPower = if (power < 0) NO_EFFECT_VALUE else power.toString()
     val formattedResult = if (calculatedResult < 0) NO_EFFECT_VALUE else String.format(format, calculatedResult)
+    val formattedAccuracy = if (accuracy < 0) NO_EFFECT_VALUE else String.format(format, accuracy)
     val color =
         when {
             multiplier < 1.0 -> R.color.poke_grey_60
@@ -32,7 +33,7 @@ fun BattlePrediction.toUi(format: String = DEFAULT_NUMBER_FORMAT): BattlePredict
 
     return BattlePredictionUiModel(
         power = formattedPower,
-        accuracy = String.format(format, accuracy),
+        accuracy = formattedAccuracy,
         multiplier = String.format(format, multiplier),
         calculatedResult = formattedResult,
         colorRes = color,

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/pokemon/PokemonSelectionFragment.kt
@@ -19,8 +19,7 @@ import poke.rogue.helper.presentation.util.view.LinearSpacingItemDecoration
 import poke.rogue.helper.presentation.util.view.dp
 import poke.rogue.helper.presentation.util.view.setOnSearchAction
 
-class PokemonSelectionFragment :
-    ErrorHandleFragment<FragmentPokemonSelectionBinding>(R.layout.fragment_pokemon_selection) {
+class PokemonSelectionFragment : ErrorHandleFragment<FragmentPokemonSelectionBinding>(R.layout.fragment_pokemon_selection) {
     private val sharedViewModel: BattleSelectionViewModel by activityViewModels()
     private val viewModel: PokemonSelectionViewModel by viewModels<PokemonSelectionViewModel> {
         PokemonSelectionViewModel.factory(
@@ -72,7 +71,12 @@ class PokemonSelectionFragment :
     private fun initObserver() {
         repeatOnStarted {
             viewModel.filteredPokemon.collect {
-                pokemonAdapter.submitList(it)
+                pokemonAdapter.submitList(it) {
+                    if (sharedViewModel.previousSelection.selectedPokemon() != null) {
+                        val position = it.indexOfFirst { it.isSelected }
+                        binding.rvPokemons.scrollToPosition(position)
+                    }
+                }
             }
         }
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -81,7 +81,7 @@ class SkillSelectionFragment :
         repeatOnStarted {
             viewModel.filteredSkills.collect {
                 skillAdapter.submitList(it) {
-                    if (viewModel.previousSkillsId != null) {
+                    if (viewModel.previousSkillId != null) {
                         val position = it.indexOfFirst { it.isSelected }
                         binding.rvSkills.scrollToPosition(position)
                     }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -80,7 +80,12 @@ class SkillSelectionFragment :
 
         repeatOnStarted {
             viewModel.filteredSkills.collect {
-                skillAdapter.submitList(it)
+                skillAdapter.submitList(it) {
+                    if (viewModel.previousSkillsId != null) {
+                        val position = it.indexOfFirst { it.isSelected }
+                        binding.rvSkills.scrollToPosition(position)
+                    }
+                }
             }
         }
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionViewModel.kt
@@ -37,7 +37,7 @@ class SkillSelectionViewModel(
     var previousPokemonDexNumber: Long? = previousSelection?.selectedPokemon?.dexNumber
         private set
 
-    var previousSkillsId: String? = previousSelection?.selectedSkill?.id
+    var previousSkillId: String? = previousSelection?.selectedSkill?.id
         private set
 
     private val _skillSelectedEvent = MutableSharedFlow<SkillSelectionUiModel>()
@@ -72,7 +72,7 @@ class SkillSelectionViewModel(
         viewModelScope.launch {
             _skillSelectedEvent.emit(selected)
         }
-        previousSkillsId = selected.id
+        previousSkillId = selected.id
     }
 
     fun updateSkills(pokemonDexNumber: Long) {
@@ -89,7 +89,7 @@ class SkillSelectionViewModel(
             viewModelScope.launch(errorHandler) {
                 val availableSkills =
                     battleRepository.availableSkills(pokemonDexNumber).map { it.toUi() }
-                _skills.value = availableSkills.toSelectableModelsBy { it.id == previousSkillsId }
+                _skills.value = availableSkills.toSelectableModelsBy { it.id == previousSkillId }
             }
         }
     }

--- a/android/data/src/main/java/poke/rogue/helper/data/datasource/RemoteBattleDataSource.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/datasource/RemoteBattleDataSource.kt
@@ -30,7 +30,6 @@ class RemoteBattleDataSource(
             }
             .getOrThrow()
             .map { it.toData() }
-            .filter { it.power > 0 }
 
     suspend fun calculatedBattlePrediction(
         weatherId: String,

--- a/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultBattleRepository.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultBattleRepository.kt
@@ -8,7 +8,7 @@ import poke.rogue.helper.data.model.Weather
 class DefaultBattleRepository(private val remoteBattleDataSource: RemoteBattleDataSource) : BattleRepository {
     override suspend fun weathers(): List<Weather> = remoteBattleDataSource.weathers()
 
-    override suspend fun availableSkills(dexNumber: Long): List<BattleSkill> = remoteBattleDataSource.availableSkills(dexNumber)
+    override suspend fun availableSkills(dexNumber: Long): List<BattleSkill> = remoteBattleDataSource.availableSkills(dexNumber).distinct()
 
     override suspend fun calculatedBattlePrediction(
         weatherId: String,


### PR DESCRIPTION
- closed #313 #314 
-> 작업 단위가 작아서 두 개 이슈 합침 이슈

## 작업 영상
https://github.com/user-attachments/assets/8237680c-d13d-4132-a927-44552cef05dc

## 작업한 내용
- 기술 위력이 마이너스 값일 경우, `-`로 표시
- 배수 값 별 색상 다르게 표시 ( 1 미만 : 회색 / 1 ~ 2 : 빨강 / 3 이상 : 초록)
- 이미 선택한 값이 있는 경우, 해당 위치로 스크롤해서 보여주기
- 중복 기술 값이 존재해서 일단 `distinct`로 방지해두었습니당

## 🚀Next Feature
- 배틀 구도 정보 저장