### PR TITLE
[1.1.0/AN_FEAT] 배틀 선택 데이터 저장

### DIFF
--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleActivity.kt
@@ -22,7 +22,7 @@ import poke.rogue.helper.presentation.util.view.setImage
 
 class BattleActivity : ToolbarActivity<ActivityBattleBinding>(R.layout.activity_battle) {
     private val viewModel by viewModels<BattleViewModel> {
-        BattleViewModel.factory(DefaultBattleRepository.instance())
+        BattleViewModel.factory(DefaultBattleRepository.instance(this))
     }
     private val weatherAdapter by lazy {
         WeatherSpinnerAdapter(this)

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionsState.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionsState.kt
@@ -12,7 +12,7 @@ data class BattleSelectionsState(
 ) {
     val allSelected: Boolean
         get() =
-            minePokemon.isSelected() && skill.isSelected() && opponentPokemon.isSelected()
+            minePokemon.isSelected() && skill.isSelected() && opponentPokemon.isSelected() && weather.isSelected()
 
     companion object {
         val DEFAULT =

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionsState.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleSelectionsState.kt
@@ -12,7 +12,7 @@ data class BattleSelectionsState(
 ) {
     val allSelected: Boolean
         get() =
-            minePokemon.isSelected() && skill.isSelected() && opponentPokemon.isSelected() && weather.isSelected()
+            listOf(minePokemon, skill, opponentPokemon, weather).all { it.isSelected() }
 
     companion object {
         val DEFAULT =

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -24,7 +24,7 @@ class SkillSelectionFragment :
     private val sharedViewModel: BattleSelectionViewModel by activityViewModels()
     private val viewModel: SkillSelectionViewModel by viewModels<SkillSelectionViewModel> {
         SkillSelectionViewModel.factory(
-            DefaultBattleRepository.instance(requireContext()),
+            DefaultBattleRepository.instance(requireContext().applicationContext),
             sharedViewModel.previousSelection as? SelectionData.WithSkill,
         )
     }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/selection/skill/SkillSelectionFragment.kt
@@ -24,7 +24,7 @@ class SkillSelectionFragment :
     private val sharedViewModel: BattleSelectionViewModel by activityViewModels()
     private val viewModel: SkillSelectionViewModel by viewModels<SkillSelectionViewModel> {
         SkillSelectionViewModel.factory(
-            DefaultBattleRepository.instance(),
+            DefaultBattleRepository.instance(requireContext()),
             sharedViewModel.previousSelection as? SelectionData.WithSkill,
         )
     }

--- a/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalBattleDataSource.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalBattleDataSource.kt
@@ -15,7 +15,9 @@ class LocalBattleDataSource(private val battleDataStore: BattleDataStore) {
         battleDataStore.savePokemonWithSkill(pokemonId, skillId)
     }
 
-    suspend fun savePokemon(pokemonId: String) = battleDataStore.savePokemon(pokemonId)
+    suspend fun savePokemon(pokemonId: String) {
+        battleDataStore.savePokemon(pokemonId)
+    }
 
     fun pokemonWithSkill(): Flow<PokemonWithSkillIds?> = battleDataStore.pokemonWithSkillId().map { it?.toData() }
 

--- a/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalBattleDataSource.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalBattleDataSource.kt
@@ -1,0 +1,35 @@
+package poke.rogue.helper.data.datasource
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import poke.rogue.helper.data.model.PokemonWithSkillIds
+import poke.rogue.helper.data.model.toData
+import poke.rogue.helper.local.datastore.BattleDataStore
+
+class LocalBattleDataSource(private val battleDataStore: BattleDataStore) {
+    suspend fun savePokemonWithSkill(
+        pokemonId: String,
+        skillId: String,
+    ) {
+        battleDataStore.savePokemonWithSkill(pokemonId, skillId)
+    }
+
+    suspend fun savePokemon(pokemonId: String) = battleDataStore.savePokemon(pokemonId)
+
+    fun pokemonWithSkill(): Flow<PokemonWithSkillIds?> = battleDataStore.pokemonWithSkillId().map { it?.toData() }
+
+    fun pokemonId(): Flow<String?> = battleDataStore.pokemonId()
+
+    companion object {
+        private var instance: LocalBattleDataSource? = null
+
+        fun instance(context: Context): LocalBattleDataSource {
+            return instance ?: LocalBattleDataSource(
+                BattleDataStore(context),
+            ).also {
+                instance = it
+            }
+        }
+    }
+}

--- a/android/data/src/main/java/poke/rogue/helper/data/model/PokemonWithSkillIds.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/model/PokemonWithSkillIds.kt
@@ -1,0 +1,9 @@
+package poke.rogue.helper.data.model
+
+import poke.rogue.helper.local.datastore.SavedPokemonWithSkill
+
+data class PokemonWithSkillIds(val pokemonId: String, val skillId: String)
+
+fun SavedPokemonWithSkill.toData() = PokemonWithSkillIds(pokemonId, skillId)
+
+data class PokemonWithSkill(val pokemon: Pokemon, val skill: BattleSkill)

--- a/android/data/src/main/java/poke/rogue/helper/data/repository/BattleRepository.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/repository/BattleRepository.kt
@@ -1,7 +1,10 @@
 package poke.rogue.helper.data.repository
 
+import kotlinx.coroutines.flow.Flow
 import poke.rogue.helper.data.model.BattlePrediction
 import poke.rogue.helper.data.model.BattleSkill
+import poke.rogue.helper.data.model.Pokemon
+import poke.rogue.helper.data.model.PokemonWithSkill
 import poke.rogue.helper.data.model.Weather
 
 interface BattleRepository {
@@ -15,4 +18,15 @@ interface BattleRepository {
         mySkillId: String,
         opponentPokemonId: String,
     ): BattlePrediction
+
+    suspend fun savePokemon(pokemonId: String)
+
+    suspend fun savePokemonWithSkill(
+        pokemonId: String,
+        skillId: String,
+    )
+
+    suspend fun savedPokemon(): Flow<Pokemon?>
+
+    suspend fun savedPokemonWithSkill(): Flow<PokemonWithSkill?>
 }

--- a/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultBattleRepository.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultBattleRepository.kt
@@ -16,7 +16,7 @@ class DefaultBattleRepository(
     private val remoteBattleDataSource: RemoteBattleDataSource,
     private val pokemonRepository: DexRepository,
 ) : BattleRepository {
-    private val cachedSkills: HashMap<Long, List<BattleSkill>> = hashMapOf()
+    private val cachedSkills: MutableMap<Long, List<BattleSkill>> = mutableMapOf()
 
     override suspend fun weathers(): List<Weather> = remoteBattleDataSource.weathers()
 
@@ -40,12 +40,16 @@ class DefaultBattleRepository(
             opponentPokemonId = opponentPokemonId,
         )
 
-    override suspend fun savePokemon(pokemonId: String) = localBattleDataSource.savePokemon(pokemonId)
+    override suspend fun savePokemon(pokemonId: String) {
+        localBattleDataSource.savePokemon(pokemonId)
+    }
 
     override suspend fun savePokemonWithSkill(
         pokemonId: String,
         skillId: String,
-    ) = localBattleDataSource.savePokemonWithSkill(pokemonId, skillId)
+    ) {
+        localBattleDataSource.savePokemonWithSkill(pokemonId, skillId)
+    }
 
     override suspend fun savedPokemon(): Flow<Pokemon?> =
         localBattleDataSource.pokemonId().map { it?.let { pokemonRepository.pokemon(it) } }

--- a/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultBattleRepository.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultBattleRepository.kt
@@ -1,11 +1,21 @@
 package poke.rogue.helper.data.repository
 
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import poke.rogue.helper.data.datasource.LocalBattleDataSource
 import poke.rogue.helper.data.datasource.RemoteBattleDataSource
 import poke.rogue.helper.data.model.BattlePrediction
 import poke.rogue.helper.data.model.BattleSkill
+import poke.rogue.helper.data.model.Pokemon
+import poke.rogue.helper.data.model.PokemonWithSkill
 import poke.rogue.helper.data.model.Weather
 
-class DefaultBattleRepository(private val remoteBattleDataSource: RemoteBattleDataSource) : BattleRepository {
+class DefaultBattleRepository(
+    private val localBattleDataSource: LocalBattleDataSource,
+    private val remoteBattleDataSource: RemoteBattleDataSource,
+    private val pokemonRepository: DexRepository,
+) : BattleRepository {
     override suspend fun weathers(): List<Weather> = remoteBattleDataSource.weathers()
 
     override suspend fun availableSkills(dexNumber: Long): List<BattleSkill> = remoteBattleDataSource.availableSkills(dexNumber).distinct()
@@ -23,11 +33,37 @@ class DefaultBattleRepository(private val remoteBattleDataSource: RemoteBattleDa
             opponentPokemonId = opponentPokemonId,
         )
 
+    override suspend fun savePokemon(pokemonId: String) = localBattleDataSource.savePokemon(pokemonId)
+
+    override suspend fun savePokemonWithSkill(
+        pokemonId: String,
+        skillId: String,
+    ) = localBattleDataSource.savePokemonWithSkill(pokemonId, skillId)
+
+    override suspend fun savedPokemon(): Flow<Pokemon?> =
+        localBattleDataSource.pokemonId().map { it?.let { pokemonRepository.pokemon(it) } }
+
+    override suspend fun savedPokemonWithSkill(): Flow<PokemonWithSkill?> =
+        localBattleDataSource.pokemonWithSkill().map {
+            it?.let { pokemonWithSkill ->
+                val pokemon = pokemonRepository.pokemon(pokemonWithSkill.pokemonId)
+                val skill =
+                    availableSkills(pokemon.dexNumber).find {
+                        it.id == pokemonWithSkill.skillId
+                    } ?: error("아이디에 해당하는 스킬이 존재하지 않습니다. id: ${pokemonWithSkill.skillId}")
+                PokemonWithSkill(pokemon, skill)
+            }
+        }
+
     companion object {
         private var instance: BattleRepository? = null
 
-        fun instance(): BattleRepository {
-            return instance ?: DefaultBattleRepository(RemoteBattleDataSource.instance()).also {
+        fun instance(context: Context): BattleRepository {
+            return instance ?: DefaultBattleRepository(
+                LocalBattleDataSource.instance(context),
+                RemoteBattleDataSource.instance(),
+                DefaultDexRepository.instance(),
+            ).also {
                 instance = it
             }
         }

--- a/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultDexRepository.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultDexRepository.kt
@@ -59,6 +59,13 @@ class DefaultDexRepository(
         }
     }
 
+    override suspend fun pokemon(id: String): Pokemon {
+        cachedPokemons.find { it.id == id }?.let {
+            return it
+        }
+        return pokemons().find { it.id == id } ?: error("아이디에 해당하는 포켓몬이 존재하지 않습니다. id : $id")
+    }
+
     private suspend fun pokemonDetail(
         id: String,
         allBiomes: List<Biome>,

--- a/android/data/src/main/java/poke/rogue/helper/data/repository/DexRepository.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/repository/DexRepository.kt
@@ -17,4 +17,6 @@ interface DexRepository {
     ): List<Pokemon>
 
     suspend fun pokemonDetail(id: String): PokemonDetail
+
+    suspend fun pokemon(id: String): Pokemon
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ coil = "2.6.0"
 glide = "4.14.2"
 ktlint = "12.1.0"
 splash-screen = "1.0.1"
+datastore = "1.0.0"
 
 # Google & Firebase
 google-services = "4.4.2"
@@ -81,6 +82,7 @@ room = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 flexbox = { module = "com.google.android.flexbox:flexbox", version.ref = "flexbox" }
+datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
 # Google & Firebase
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }

--- a/android/local/build.gradle.kts
+++ b/android/local/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
@@ -46,12 +47,14 @@ android {
 
 dependencies {
     implementation(libs.kotlin.coroutines.android)
+    implementation(libs.kotlin.serialization.json)
     // third-party
     implementation(libs.timber)
     // room
     implementation(libs.room)
     implementation(libs.room.ktx)
     kapt(libs.room.compiler)
+    implementation(libs.datastore.preferences)
     // unit test
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.kotlin.test)

--- a/android/local/src/main/java/poke/rogue/helper/local/datastore/BattleDataStore.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/datastore/BattleDataStore.kt
@@ -1,3 +1,4 @@
+
 package poke.rogue.helper.local.datastore
 
 import android.content.Context

--- a/android/local/src/main/java/poke/rogue/helper/local/datastore/BattleDataStore.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/datastore/BattleDataStore.kt
@@ -1,0 +1,58 @@
+package poke.rogue.helper.local.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class SavedPokemonWithSkill(val pokemonId: String, val skillId: String)
+
+class BattleDataStore(private val context: Context) {
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = BATTLE_PREFERENCE_NAME)
+
+    suspend fun savePokemonWithSkill(
+        pokemonId: String,
+        skillId: String,
+    ) {
+        val data = SavedPokemonWithSkill(pokemonId, skillId)
+        val saved = Json.encodeToString(data)
+        context.dataStore.edit {
+            it[POKEMON_WITH_SKILL_SELECTION_KEY] = saved
+        }
+    }
+
+    suspend fun savePokemon(pokemonId: String) {
+        context.dataStore.edit {
+            it[POKEMON_SELECTION_KEY] = pokemonId
+        }
+    }
+
+    fun pokemonWithSkillId(): Flow<SavedPokemonWithSkill?> =
+        context.dataStore.data.map { preference ->
+            val data = preference[POKEMON_WITH_SKILL_SELECTION_KEY]
+            if (data != null) {
+                Json.decodeFromString<SavedPokemonWithSkill>(data)
+            } else {
+                null
+            }
+        }
+
+    fun pokemonId(): Flow<String?> =
+        context.dataStore.data.map { preferences ->
+            preferences[POKEMON_SELECTION_KEY]
+        }
+
+    private companion object {
+        const val BATTLE_PREFERENCE_NAME = "battle"
+        val POKEMON_WITH_SKILL_SELECTION_KEY = stringPreferencesKey("pokemon_with_skill_selection")
+        val POKEMON_SELECTION_KEY = stringPreferencesKey("pokemon_selection")
+    }
+}

--- a/android/local/src/main/java/poke/rogue/helper/local/datastore/BattleDataStore.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/datastore/BattleDataStore.kt
@@ -9,11 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 
-@Serializable
 data class SavedPokemonWithSkill(val pokemonId: String, val skillId: String)
 
 class BattleDataStore(private val context: Context) {
@@ -23,37 +19,38 @@ class BattleDataStore(private val context: Context) {
         pokemonId: String,
         skillId: String,
     ) {
-        val data = SavedPokemonWithSkill(pokemonId, skillId)
-        val saved = Json.encodeToString(data)
         context.dataStore.edit {
-            it[POKEMON_WITH_SKILL_SELECTION_KEY] = saved
+            it[PAIR_POKEMON_SELECTION_KEY] = pokemonId
+            it[PAIR_SKILL_SELECTION_KEY] = skillId
         }
     }
 
     suspend fun savePokemon(pokemonId: String) {
         context.dataStore.edit {
-            it[POKEMON_SELECTION_KEY] = pokemonId
+            it[SINGLE_POKEMON_SELECTION_KEY] = pokemonId
         }
     }
 
     fun pokemonWithSkillId(): Flow<SavedPokemonWithSkill?> =
         context.dataStore.data.map { preference ->
-            val data = preference[POKEMON_WITH_SKILL_SELECTION_KEY]
-            if (data != null) {
-                Json.decodeFromString<SavedPokemonWithSkill>(data)
-            } else {
+            val pokemonId = preference[PAIR_POKEMON_SELECTION_KEY]
+            val skillId = preference[PAIR_SKILL_SELECTION_KEY]
+            if (pokemonId == null || skillId == null) {
                 null
+            } else {
+                SavedPokemonWithSkill(pokemonId, skillId)
             }
         }
 
     fun pokemonId(): Flow<String?> =
         context.dataStore.data.map { preferences ->
-            preferences[POKEMON_SELECTION_KEY]
+            preferences[SINGLE_POKEMON_SELECTION_KEY]
         }
 
     private companion object {
         const val BATTLE_PREFERENCE_NAME = "battle"
-        val POKEMON_WITH_SKILL_SELECTION_KEY = stringPreferencesKey("pokemon_with_skill_selection")
-        val POKEMON_SELECTION_KEY = stringPreferencesKey("pokemon_selection")
+        val PAIR_POKEMON_SELECTION_KEY = stringPreferencesKey("pair_pokemon_selection")
+        val PAIR_SKILL_SELECTION_KEY = stringPreferencesKey("pair_skill_selection")
+        val SINGLE_POKEMON_SELECTION_KEY = stringPreferencesKey("single_pokemon_selection")
     }
 }

--- a/android/testing/src/main/java/poke/rogue/helper/testing/data/repository/FakeDexRepository.kt
+++ b/android/testing/src/main/java/poke/rogue/helper/testing/data/repository/FakeDexRepository.kt
@@ -51,9 +51,7 @@ class FakeDexRepository : DexRepository {
             weight = 6.9,
         )
 
-    override suspend fun pokemon(id: String): Pokemon {
-        TODO("Not yet implemented")
-    }
+    override suspend fun pokemon(id: String): Pokemon = pokemons().find { it.id == id } ?: error("존재하지 않는 포켓몬 ID : $id")
 
     private fun List<Pokemon>.toFilteredPokemons(
         sort: PokemonSort,

--- a/android/testing/src/main/java/poke/rogue/helper/testing/data/repository/FakeDexRepository.kt
+++ b/android/testing/src/main/java/poke/rogue/helper/testing/data/repository/FakeDexRepository.kt
@@ -51,6 +51,10 @@ class FakeDexRepository : DexRepository {
             weight = 6.9,
         )
 
+    override suspend fun pokemon(id: String): Pokemon {
+        TODO("Not yet implemented")
+    }
+
     private fun List<Pokemon>.toFilteredPokemons(
         sort: PokemonSort,
         filters: List<PokemonFilter>,


### PR DESCRIPTION
- closed #323
## 작업 영상
- PASS

## 작업한 내용
- 내 포켓몬, 기술, 상대 포켓몬 선택 데이터 저장 기능 구현
- `Datastore`을 사용하여 해당 데이터들을 저장했습니다.
- 현재 skill ID 값으로 해당 skill 데이터를 불러오는 API 는 따로 없어서 일단 이 전에 불러왔던 skill들을 map 형식으로 캐싱해두고, 나중에 find를 활용하여 해당하는 Skill 데이터를 찾을 수 있도록 설정했습니다.
- `Dex Repository` 에서도 포켓몬 ID를 넘기면 해당 `Pokemon` 을 반환해주는 메서드도 추가했습니다!
   -  기존에 있던 부분은 Detail을 반환하기 때문

## 🚀Next Feature
