### PR TITLE
[1.1.0/AN-FEAT] 룸 엔티티 수정 대응(destructive-recreation)

### DIFF
--- a/android/local/src/main/java/poke/rogue/helper/local/dao/PokemonDao.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/dao/PokemonDao.kt
@@ -18,7 +18,6 @@ interface PokemonDao {
 
     companion object {
         fun instance(context: Context): PokemonDao {
-            PokeRogueDatabase.dropDatabase(context)
             return PokeRogueDatabase.instance(context).pokemonDao()
         }
     }

--- a/android/local/src/main/java/poke/rogue/helper/local/db/PokeRogueDatabase.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/db/PokeRogueDatabase.kt
@@ -10,7 +10,7 @@ import poke.rogue.helper.local.entity.PokemonEntity
 
 @Database(
     entities = [PokemonEntity::class],
-    version = 1,
+    version = 2,
 )
 @androidx.room.TypeConverters(PokemonTypeConverters::class)
 abstract class PokeRogueDatabase : RoomDatabase() {
@@ -28,15 +28,10 @@ abstract class PokeRogueDatabase : RoomDatabase() {
                     context,
                     PokeRogueDatabase::class.java,
                     DATABASE_NAME,
-                ).build().also { instance = it }
+                )
+                    .fallbackToDestructiveMigration()
+                    .build().also { instance = it }
             }
         }
-
-        fun dropDatabase(context: Context) =
-            synchronized(this) {
-                instance?.close()
-                instance = null
-                context.deleteDatabase(DATABASE_NAME)
-            }
     }
 }


### PR DESCRIPTION
- closed #354 
## 작업 영상
그런 건 없어요~

## 작업한 내용
-  룸 엔티티 변경에 대해 대응한다.

## PR 포인트
#### 결론 
--- 
기존: 앱을 켤 때마다 항상 룸 DB 드롭하고 새로 만듭니다.
변경됨: 룸 엔티티의 정보가 바뀌었을 때만, 룸 DB 를 드롭하고 새로 만듭니다.

룸 AutoMigration 은 안 썼습니다.
이틀 삽질 엄청했는데 결과는 코드 3줄 넣으면 되는 거였네요 ㅋㅋㅋㅋㅋ

#### 상황 설명
---
상황 설명을 드릴게요. 
1. 현재 구조: DB 에서 포켓몬 조회합니다.  비어있으면 서버로부터 요청하여 DB 에 포켓몬 데이터들을 저장합니다..
2. DB 엔티티에 backImageUrl 이 추가되었으니, DB 에 저장된 데이터들을 업데이트 해야 한다.
3. 즉, 우리는 서버로부터 받은 포켓몬 데이터를 다시 DB 에 저장해야 합니다.

방법1. 
그러러면, 전체 포켓몬 목록 API 를 호출해서 backImageUrl 을 필터링 한 다음에 DB 에 데이터를 직접 넣어주어야 합니다.
이렇게 하면 기존 DB 데이터들은 유지하고 새로 추가된 데이터만 DB 에 넣어줄 수 있습니다.

방법2. 
하지만 저는 그냥 룸 엔티티의 정보가 바뀌었을 때만, 룸 DB 를 드롭하고 새로 만들도록 구현했습니다.

#### 방법 1 이 별로인 이유.
1. 공수가 너무 많이 듭니다. 단순 엔티티가 하나 추가되었는데 기존에 있던 데이터 칼럼과 비교하고 필터링하고 다시 넣어주는 로직이 생깁니다.
2. 만약 다음에 또 다른 엔티티가 추가된다고 하면, 일일이 다시 로직을 수정해야주어야 합니다.

#### 방법 2가 괜찮은 이유.
1. 공수가 적게 든다.
2. 캐시된 데이터의 손실이 큰 문제가 되지 않는다.

## 🚀Next Feature
글쎄요..?
일단 미션 좀 하고 내일 팀원들에게 의견 물어볼게요