### PR TITLE
[1.1.0/AN-FEAT] 인앱 업데이트 기능 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -200,6 +200,8 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics.buildtools)
     implementation(libs.bundles.firebase)
+    implementation(libs.app.update)
+    implementation(libs.app.update.ktx)
     // android test
     androidTestImplementation(libs.bundles.android.test)
     androidTestRuntimeOnly(libs.junit5.android.test.runner)

--- a/android/app/src/main/java/poke/rogue/helper/presentation/home/HomeActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/home/HomeActivity.kt
@@ -50,16 +50,17 @@ class HomeActivity : ToolbarActivity<ActivityHomeBinding>(R.layout.activity_home
         updateManager = UpdateManager(applicationContext)
         updateManager.registerInstallStateUpdateListener()
 
-        val appUpdateLauncher = registerForActivityResult(
-            ActivityResultContracts.StartIntentSenderForResult()
-        ) { result ->
-            // logger도 달아야겠죠??
-            if (result.resultCode == RESULT_OK) {
-                Timber.i("Update completed successfully")
-            } else {
-                Timber.e("Update failed, result code: ${result.resultCode}")
+        val appUpdateLauncher =
+            registerForActivityResult(
+                ActivityResultContracts.StartIntentSenderForResult(),
+            ) { result ->
+                // logger도 달아야겠죠??
+                if (result.resultCode == RESULT_OK) {
+                    Timber.i("Update completed successfully")
+                } else {
+                    Timber.e("Update failed, result code: ${result.resultCode}")
+                }
             }
-        }
         updateManager.checkForAppUpdates(appUpdateLauncher)
     }
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/home/HomeActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/home/HomeActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.widget.Toolbar
 import poke.rogue.helper.R
@@ -22,18 +23,44 @@ import poke.rogue.helper.presentation.util.context.stringOf
 import poke.rogue.helper.presentation.util.context.toast
 import poke.rogue.helper.presentation.util.logClickEvent
 import poke.rogue.helper.presentation.util.repeatOnStarted
+import poke.rogue.helper.update.UpdateManager
+import timber.log.Timber
 
 class HomeActivity : ToolbarActivity<ActivityHomeBinding>(R.layout.activity_home) {
     private val viewModel by viewModels<HomeViewModel>()
     private val logger: AnalyticsLogger = analyticsLogger()
+    private lateinit var updateManager: UpdateManager
 
     override val toolbar: Toolbar
         get() = binding.toolbarHome
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        initUpdateManager()
         initViews()
         initObservers()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        updateManager.unregisterInstallStateUpdateListener()
+    }
+
+    private fun initUpdateManager() {
+        updateManager = UpdateManager(applicationContext)
+        updateManager.registerInstallStateUpdateListener()
+
+        val appUpdateLauncher = registerForActivityResult(
+            ActivityResultContracts.StartIntentSenderForResult()
+        ) { result ->
+            // logger도 달아야겠죠??
+            if (result.resultCode == RESULT_OK) {
+                Timber.i("Update completed successfully")
+            } else {
+                Timber.e("Update failed, result code: ${result.resultCode}")
+            }
+        }
+        updateManager.checkForAppUpdates(appUpdateLauncher)
     }
 
     private fun initViews() =

--- a/android/app/src/main/java/poke/rogue/helper/update/UpdateManager.kt
+++ b/android/app/src/main/java/poke/rogue/helper/update/UpdateManager.kt
@@ -1,0 +1,65 @@
+package poke.rogue.helper.update
+
+import android.content.Context
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import com.google.android.play.core.appupdate.AppUpdateInfo
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import timber.log.Timber
+
+
+class UpdateManager(
+    private val context: Context
+) {
+    private val appUpdateManager: AppUpdateManager = AppUpdateManagerFactory.create(context)
+    private val updateType = AppUpdateType.FLEXIBLE
+
+    private val installStateUpdateListener = InstallStateUpdatedListener { state ->
+        when (state.installStatus()) {
+            InstallStatus.INSTALLING -> Timber.i("Update is downloading")
+
+            InstallStatus.DOWNLOADED -> {
+                Timber.i("Update installed successfully")
+                appUpdateManager.completeUpdate()
+            }
+
+            InstallStatus.CANCELED -> Timber.e("Update was cancelled")
+        }
+    }
+
+    fun checkForAppUpdates(
+        appUpdateLauncher: ActivityResultLauncher<IntentSenderRequest>
+    ) {
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+            if (checkForAppUpdate(info)) {
+                val updateOptions = AppUpdateOptions.newBuilder(updateType).build()
+                appUpdateManager.startUpdateFlowForResult(
+                    info,
+                    appUpdateLauncher,
+                    updateOptions
+                )
+            }
+        }
+    }
+
+    private fun checkForAppUpdate(info: AppUpdateInfo): Boolean {
+        val isUpdateAvailable = info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+        val isUpdateAllowed = info.isUpdateTypeAllowed(updateType)
+        return isUpdateAvailable && isUpdateAllowed
+    }
+
+
+    fun registerInstallStateUpdateListener() {
+        appUpdateManager.registerListener(installStateUpdateListener)
+    }
+
+    fun unregisterInstallStateUpdateListener() {
+        appUpdateManager.unregisterListener(installStateUpdateListener)
+    }
+}

--- a/android/app/src/main/java/poke/rogue/helper/update/UpdateManager.kt
+++ b/android/app/src/main/java/poke/rogue/helper/update/UpdateManager.kt
@@ -13,36 +13,34 @@ import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
 import timber.log.Timber
 
-
 class UpdateManager(
-    private val context: Context
+    private val context: Context,
 ) {
     private val appUpdateManager: AppUpdateManager = AppUpdateManagerFactory.create(context)
     private val updateType = AppUpdateType.FLEXIBLE
 
-    private val installStateUpdateListener = InstallStateUpdatedListener { state ->
-        when (state.installStatus()) {
-            InstallStatus.INSTALLING -> Timber.i("Update is downloading")
+    private val installStateUpdateListener =
+        InstallStateUpdatedListener { state ->
+            when (state.installStatus()) {
+                InstallStatus.INSTALLING -> Timber.i("Update is downloading")
 
-            InstallStatus.DOWNLOADED -> {
-                Timber.i("Update installed successfully")
-                appUpdateManager.completeUpdate()
+                InstallStatus.DOWNLOADED -> {
+                    Timber.i("Update installed successfully")
+                    appUpdateManager.completeUpdate()
+                }
+
+                InstallStatus.CANCELED -> Timber.e("Update was cancelled")
             }
-
-            InstallStatus.CANCELED -> Timber.e("Update was cancelled")
         }
-    }
 
-    fun checkForAppUpdates(
-        appUpdateLauncher: ActivityResultLauncher<IntentSenderRequest>
-    ) {
+    fun checkForAppUpdates(appUpdateLauncher: ActivityResultLauncher<IntentSenderRequest>) {
         appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
             if (checkForAppUpdate(info)) {
                 val updateOptions = AppUpdateOptions.newBuilder(updateType).build()
                 appUpdateManager.startUpdateFlowForResult(
                     info,
                     appUpdateLauncher,
-                    updateOptions
+                    updateOptions,
                 )
             }
         }
@@ -53,7 +51,6 @@ class UpdateManager(
         val isUpdateAllowed = info.isUpdateTypeAllowed(updateType)
         return isUpdateAvailable && isUpdateAllowed
     }
-
 
     fun registerInstallStateUpdateListener() {
         appUpdateManager.registerListener(installStateUpdateListener)

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ datastore = "1.0.0"
 google-services = "4.4.2"
 firebase = "33.1.2"
 firebase-crashlytics = "3.0.2"
+app-update = "2.1.0"
 
 # Android-Test
 android-junit5-plugin = "1.10.0.0"
@@ -89,6 +90,8 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 firebase-crashlytics-plugin = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "firebase-crashlytics" }
+app-update = { module = "com.google.android.play:app-update", version.ref = "app-update" }
+app-update-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "app-update" }
 # android test
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }
 android-test-fragment = { module = "androidx.fragment:fragment-testing", version.ref = "androidx-test-fragment" }


### PR DESCRIPTION
- closed #353 

## 작업한 내용
- 인앱 업데이트를 FLEXIBLE 하게 업데이트 하도록 추가하였습니다. 

[an:feat:강제업데이트.webm](https://github.com/user-attachments/assets/dfa744bb-373d-43c6-9ad7-4a5da4ea2f5b)


## PR 포인트
- 앱을 사용자가 안받으면 어떻게 할지 로직을 안세웠어요 -> 같이 이야기 해봐야할 듯??  서버에서 하위호환성을 구현해주면 필요 없을 것 같긴함
- 위와 비슷하게 앱 다운로드 중 실패한다면, 어떻게 되도록 해야할지도 의견을 물어보고 싶어요.
- (또 궁금증..) 현재 업데이트 되는 화면이 HomeActivity에서 업데이트를 진행하고 있습니다. 시작화면(HomeActivity)과 스플래시화면 중 어디서 업데이트를 유도하는게 맞을까요?? 보통 두 곳에서 많이 한다고는 합니다 https://stackoverflow.com/questions/60188371/where-to-add-the-code-for-checking-in-app-updates-in-android-would-it-be-fine-i

## 🚀Next Feature
- 팀원들과 이야기 해보고? 아마도 로깅과 다운로드 관련한 테스크 가져가야 할듯