### PR TITLE
[BE-REFACTOR] 바이옴 포켓몬 티어 정렬

### DIFF
--- a/backend/pokerogue/src/main/java/com/pokerogue/PokerogueApplication.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/PokerogueApplication.java
@@ -2,14 +2,12 @@ package com.pokerogue;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @SpringBootApplication
-@EnableMongoRepositories
 public class PokerogueApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(PokerogueApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(PokerogueApplication.class, args);
+    }
 
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/controller/BiomeController.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/controller/BiomeController.java
@@ -1,11 +1,9 @@
 package com.pokerogue.helper.biome.controller;
 
-import static com.pokerogue.helper.biome.service.NativePokemonComparator.ASCENDING;
-import static com.pokerogue.helper.biome.service.NativePokemonComparator.DESCENDING;
-
 import com.pokerogue.helper.biome.dto.BiomeDetailResponse;
 import com.pokerogue.helper.biome.dto.BiomeResponse;
 import com.pokerogue.helper.biome.service.BiomeService;
+import com.pokerogue.helper.global.constant.SortingCriteria;
 import com.pokerogue.helper.util.dto.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,8 +27,8 @@ public class BiomeController {
 
     @GetMapping("/api/v1/biome/{id}")
     public ApiResponse<BiomeDetailResponse> biomeDetails(@PathVariable("id") String id,
-                                                         @RequestParam(value = "boss", defaultValue = DESCENDING) String bossPokemonOrder,
-                                                         @RequestParam(value = "wild", defaultValue = ASCENDING) String wildPokemonOrder) {
+                                                         @RequestParam(value = "boss", defaultValue = "desc") SortingCriteria bossPokemonOrder,
+                                                         @RequestParam(value = "wild", defaultValue = "asc") SortingCriteria wildPokemonOrder) {
         log.info(
                 "---- URI : {}, Param : {}, ThreadName : {}",
                 "/api/v1/biome/{id}",

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/controller/BiomeController.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/controller/BiomeController.java
@@ -1,7 +1,10 @@
 package com.pokerogue.helper.biome.controller;
 
-import com.pokerogue.helper.biome.dto.BiomeResponse;
+import static com.pokerogue.helper.biome.service.NativePokemonComparator.ASCENDING;
+import static com.pokerogue.helper.biome.service.NativePokemonComparator.DESCENDING;
+
 import com.pokerogue.helper.biome.dto.BiomeDetailResponse;
+import com.pokerogue.helper.biome.dto.BiomeResponse;
 import com.pokerogue.helper.biome.service.BiomeService;
 import com.pokerogue.helper.util.dto.ApiResponse;
 import java.util.List;
@@ -9,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -24,7 +28,9 @@ public class BiomeController {
     }
 
     @GetMapping("/api/v1/biome/{id}")
-    public ApiResponse<BiomeDetailResponse> biomeDetails(@PathVariable("id") String id) {
+    public ApiResponse<BiomeDetailResponse> biomeDetails(@PathVariable("id") String id,
+                                                         @RequestParam(value = "boss", defaultValue = DESCENDING) String bossPokemonOrder,
+                                                         @RequestParam(value = "wild", defaultValue = ASCENDING) String wildPokemonOrder) {
         log.info(
                 "---- URI : {}, Param : {}, ThreadName : {}",
                 "/api/v1/biome/{id}",
@@ -32,6 +38,7 @@ public class BiomeController {
                 Thread.currentThread().getName()
         );
 
-        return new ApiResponse<>("바이옴 정보 불러오기에 성공했습니다.", biomeService.findBiome(id));
+        return new ApiResponse<>("바이옴 정보 불러오기에 성공했습니다.",
+                biomeService.findBiome(id, bossPokemonOrder, wildPokemonOrder));
     }
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/converter/SortingCriteriaRequestConverter.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/converter/SortingCriteriaRequestConverter.java
@@ -1,0 +1,12 @@
+package com.pokerogue.helper.biome.converter;
+
+import com.pokerogue.helper.global.constant.SortingCriteria;
+import org.springframework.core.convert.converter.Converter;
+
+public class SortingCriteriaRequestConverter implements Converter<String, SortingCriteria> {
+
+    @Override
+    public SortingCriteria convert(String sortingCriteriaValue) {
+        return SortingCriteria.convertFrom(sortingCriteriaValue);
+    }
+}

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/data/NativePokemon.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/data/NativePokemon.java
@@ -2,15 +2,15 @@ package com.pokerogue.helper.biome.data;
 
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NativePokemon {
-
-    private static final String BOSS = "보스";
 
     @Field("tier")
     private Tier tier;
@@ -24,5 +24,9 @@ public class NativePokemon {
 
     public boolean isBoss() {
         return tier.isBoss();
+    }
+
+    public int getRarity() {
+        return this.tier.getRarity();
     }
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/data/Tier.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/data/Tier.java
@@ -8,21 +8,23 @@ import lombok.Getter;
 @Getter
 public enum Tier {
 
-    COMMON("보통"),
-    UNCOMMON("드묾"),
-    RARE("레어"),
-    SUPER_RARE("슈퍼 레어"),
-    ULTRA_RARE("울트라 레어"),
-    BOSS("보스"),
-    BOSS_RARE("레어 보스"),
-    BOSS_SUPER_RARE("슈퍼 레어 보스"),
-    BOSS_ULTRA_RARE("슈퍼 울트라 레어 보스"),
+    COMMON("보통", 1),
+    UNCOMMON("드묾", 2),
+    RARE("레어", 3),
+    SUPER_RARE("슈퍼 레어", 4),
+    ULTRA_RARE("울트라 레어", 5),
+    BOSS("보스", 6),
+    BOSS_RARE("레어 보스", 7),
+    BOSS_SUPER_RARE("슈퍼 레어 보스", 8),
+    BOSS_ULTRA_RARE("슈퍼 울트라 레어 보스", 9),
     ;
 
     private final String name;
+    private final int rarity;
 
-    Tier(String name) {
+    Tier(String name, int rarity) {
         this.name = name;
+        this.rarity = rarity;
     }
 
     public boolean isWild() {

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/BiomeService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/BiomeService.java
@@ -39,32 +39,34 @@ public class BiomeService {
                 .toList();
     }
 
-    public BiomeDetailResponse findBiome(String id) {
+    public BiomeDetailResponse findBiome(String id, String bossPokemonOrder, String wildPokemonOrder) {
         Biome biome = biomeRepository.findById(id)
                 .orElseThrow(() -> new GlobalCustomException(ErrorMessage.BIOME_NOT_FOUND));
 
         return BiomeDetailResponse.of(
                 biome,
                 s3Service.getBiomeImageFromS3(biome.getId()),
-                getWildPokemons(biome.getNativePokemons()),
-                getBossPokemons(biome.getNativePokemons()),
+                getWildPokemons(biome.getNativePokemons(), wildPokemonOrder),
+                getBossPokemons(biome.getNativePokemons(), bossPokemonOrder),
                 getTrainerPokemons(biome),
                 getNextBiomes(biome)
         );
     }
 
-    private List<BiomeAllPokemonResponse> getWildPokemons(List<NativePokemon> nativePokemons) {
+    private List<BiomeAllPokemonResponse> getWildPokemons(List<NativePokemon> nativePokemons, String wildPokemonOrder) {
         return nativePokemons.stream()
                 .filter(NativePokemon::isWild)
+                .sorted(NativePokemonComparator.of(wildPokemonOrder))
                 .map(nativePokemon -> BiomeAllPokemonResponse.of(
                         nativePokemon,
                         getBiomePokemons(nativePokemon.getPokemonIds())))
                 .toList();
     }
 
-    private List<BiomeAllPokemonResponse> getBossPokemons(List<NativePokemon> nativePokemons) {
+    private List<BiomeAllPokemonResponse> getBossPokemons(List<NativePokemon> nativePokemons, String bossPokemonOrder) {
         return nativePokemons.stream()
                 .filter(NativePokemon::isBoss)
+                .sorted(NativePokemonComparator.of(bossPokemonOrder))
                 .map(nativePokemon -> BiomeAllPokemonResponse.of(
                         nativePokemon,
                         getBiomePokemons(nativePokemon.getPokemonIds())))

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/BiomeService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/BiomeService.java
@@ -12,6 +12,7 @@ import com.pokerogue.helper.biome.dto.BiomeTypeResponse;
 import com.pokerogue.helper.biome.dto.NextBiomeResponse;
 import com.pokerogue.helper.biome.dto.TrainerPokemonResponse;
 import com.pokerogue.helper.biome.repository.BiomeRepository;
+import com.pokerogue.helper.global.constant.SortingCriteria;
 import com.pokerogue.helper.global.exception.ErrorMessage;
 import com.pokerogue.helper.global.exception.GlobalCustomException;
 import com.pokerogue.helper.pokemon.repository.PokemonRepository;
@@ -39,7 +40,7 @@ public class BiomeService {
                 .toList();
     }
 
-    public BiomeDetailResponse findBiome(String id, String bossPokemonOrder, String wildPokemonOrder) {
+    public BiomeDetailResponse findBiome(String id, SortingCriteria bossPokemonOrder, SortingCriteria wildPokemonOrder) {
         Biome biome = biomeRepository.findById(id)
                 .orElseThrow(() -> new GlobalCustomException(ErrorMessage.BIOME_NOT_FOUND));
 
@@ -53,7 +54,7 @@ public class BiomeService {
         );
     }
 
-    private List<BiomeAllPokemonResponse> getWildPokemons(List<NativePokemon> nativePokemons, String wildPokemonOrder) {
+    private List<BiomeAllPokemonResponse> getWildPokemons(List<NativePokemon> nativePokemons, SortingCriteria wildPokemonOrder) {
         return nativePokemons.stream()
                 .filter(NativePokemon::isWild)
                 .sorted(NativePokemonComparator.of(wildPokemonOrder))
@@ -63,7 +64,7 @@ public class BiomeService {
                 .toList();
     }
 
-    private List<BiomeAllPokemonResponse> getBossPokemons(List<NativePokemon> nativePokemons, String bossPokemonOrder) {
+    private List<BiomeAllPokemonResponse> getBossPokemons(List<NativePokemon> nativePokemons, SortingCriteria bossPokemonOrder) {
         return nativePokemons.stream()
                 .filter(NativePokemon::isBoss)
                 .sorted(NativePokemonComparator.of(bossPokemonOrder))

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/NativePokemonComparator.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/NativePokemonComparator.java
@@ -20,6 +20,7 @@ public class NativePokemonComparator implements Comparator<NativePokemon> {
         if (criteria.equals(ASCENDING)) {
             return ASCENDING_COMPARATOR;
         }
+
         return DESCENDING_COMPARATOR;
     }
 

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/NativePokemonComparator.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/NativePokemonComparator.java
@@ -1,0 +1,34 @@
+package com.pokerogue.helper.biome.service;
+
+import com.pokerogue.helper.biome.data.NativePokemon;
+import java.util.Comparator;
+
+public class NativePokemonComparator implements Comparator<NativePokemon> {
+
+    public static final String ASCENDING = "asc";
+    public static final String DESCENDING = "desc";
+    private static final NativePokemonComparator ASCENDING_COMPARATOR = new NativePokemonComparator(ASCENDING);
+    private static final NativePokemonComparator DESCENDING_COMPARATOR = new NativePokemonComparator(DESCENDING);
+
+    private final String criteria;
+
+    private NativePokemonComparator(String criteria) {
+        this.criteria = criteria;
+    }
+
+    public static NativePokemonComparator of(String criteria) {
+        if (criteria.equals(ASCENDING)) {
+            return ASCENDING_COMPARATOR;
+        }
+        return DESCENDING_COMPARATOR;
+    }
+
+    @Override
+    public int compare(NativePokemon firstPokemon, NativePokemon secondPokemon) {
+        if (this.criteria.equals(ASCENDING)) {
+            return Integer.compare(firstPokemon.getRarity(), secondPokemon.getRarity());
+        }
+
+        return Integer.compare(secondPokemon.getRarity(), firstPokemon.getRarity());
+    }
+}

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/NativePokemonComparator.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/biome/service/NativePokemonComparator.java
@@ -1,22 +1,24 @@
 package com.pokerogue.helper.biome.service;
 
+import static com.pokerogue.helper.global.constant.SortingCriteria.ASCENDING;
+import static com.pokerogue.helper.global.constant.SortingCriteria.DESCENDING;
+
 import com.pokerogue.helper.biome.data.NativePokemon;
+import com.pokerogue.helper.global.constant.SortingCriteria;
 import java.util.Comparator;
 
 public class NativePokemonComparator implements Comparator<NativePokemon> {
 
-    public static final String ASCENDING = "asc";
-    public static final String DESCENDING = "desc";
     private static final NativePokemonComparator ASCENDING_COMPARATOR = new NativePokemonComparator(ASCENDING);
     private static final NativePokemonComparator DESCENDING_COMPARATOR = new NativePokemonComparator(DESCENDING);
 
-    private final String criteria;
+    private final SortingCriteria criteria;
 
-    private NativePokemonComparator(String criteria) {
+    private NativePokemonComparator(SortingCriteria criteria) {
         this.criteria = criteria;
     }
 
-    public static NativePokemonComparator of(String criteria) {
+    public static NativePokemonComparator of(SortingCriteria criteria) {
         if (criteria.equals(ASCENDING)) {
             return ASCENDING_COMPARATOR;
         }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/global/config/DataMongoDbConfig.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/global/config/DataMongoDbConfig.java
@@ -10,9 +10,11 @@ import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @Configuration
-public class ConverterConfig {
+@EnableMongoRepositories(basePackages = {"com.pokerogue"})
+public class DataMongoDbConfig {
 
     @Bean
     public MongoCustomConversions customConversions() {

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/global/config/WebConfig.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/global/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.pokerogue.helper.global.config;
+
+import com.pokerogue.helper.biome.converter.SortingCriteriaRequestConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new SortingCriteriaRequestConverter());
+    }
+}

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/global/constant/SortingCriteria.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/global/constant/SortingCriteria.java
@@ -1,0 +1,27 @@
+package com.pokerogue.helper.global.constant;
+
+import com.pokerogue.helper.global.exception.ErrorMessage;
+import com.pokerogue.helper.global.exception.GlobalCustomException;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum SortingCriteria {
+
+    ASCENDING("asc"),
+    DESCENDING("desc"),
+    ;
+
+    private final String value;
+
+    SortingCriteria(String value) {
+        this.value = value;
+    }
+
+    public static SortingCriteria convertFrom(String value) {
+        return Arrays.stream(values())
+                .filter(criteria -> criteria.value.equals(value))
+                .findAny()
+                .orElseThrow(() -> new GlobalCustomException(ErrorMessage.INVALID_SORTING_CRITERIA));
+    }
+}

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/global/exception/ErrorMessage.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/global/exception/ErrorMessage.java
@@ -41,9 +41,7 @@ public enum ErrorMessage {
     POKEMON_TYPE_DUPLICATION(HttpStatus.INTERNAL_SERVER_ERROR,"포켓몬의 타입은 중복될 수 없습니다."),
     POKEMON_EVOLUTION_ID_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "포켓몬과 진화 포켓몬 아이디가 서로 일치하지 않습니다"),
 
-
-
-
+    INVALID_SORTING_CRITERIA(HttpStatus.BAD_REQUEST, "지원되지 않는 정렬 기준입니다."),
     FILE_ACCESS_FAILED(HttpStatus.BAD_REQUEST, "파일 정보 접근에 실패했습니다."),
     FILE_EXTENSION_NOT_APPLY(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     ;

--- a/backend/pokerogue/src/test/java/com/pokerogue/environment/controller/ControllerTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/environment/controller/ControllerTest.java
@@ -1,0 +1,21 @@
+package com.pokerogue.environment.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("local")
+public abstract class ControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected MongoTemplate mongoTemplate;
+}

--- a/backend/pokerogue/src/test/java/com/pokerogue/environment/repository/MongoRepositoryTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/environment/repository/MongoRepositoryTest.java
@@ -1,12 +1,12 @@
 package com.pokerogue.environment.repository;
 
-import com.pokerogue.helper.global.config.ConverterConfig;
+import com.pokerogue.helper.global.config.DataMongoDbConfig;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataMongoTest
 @ActiveProfiles("local")
-@Import(ConverterConfig.class)
+@Import(DataMongoDbConfig.class)
 public abstract class MongoRepositoryTest {
 }

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/controller/BiomeControllerTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/controller/BiomeControllerTest.java
@@ -1,0 +1,58 @@
+package com.pokerogue.helper.biome.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pokerogue.environment.controller.ControllerTest;
+import com.pokerogue.helper.biome.service.BiomeService;
+import com.pokerogue.helper.global.constant.SortingCriteria;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(value = BiomeController.class)
+class BiomeControllerTest extends ControllerTest {
+
+    @MockBean
+    private BiomeService biomeService;
+
+    @Test
+    @DisplayName("바이옴 포켓몬 정렬 기준 쿼리 스트링을 바인딩한다.")
+    void bindBiomePokemonSortingCriteriaRequestParameter() throws Exception {
+        mockMvc.perform(get("/api/v1/biome/test_id")
+                        .content(MediaType.APPLICATION_JSON_VALUE)
+                        .param("boss", "asc").param("wild", "desc"))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(biomeService).findBiome("test_id", SortingCriteria.ASCENDING, SortingCriteria.DESCENDING);
+    }
+
+    @Test
+    @DisplayName("바이옴 포켓몬 정렬 기준 쿼리 스트링을 설정하지 않았다면 기본값으로 바인딩한다.")
+    void bindDefaultBiomePokemonSortingCriteriaRequestParameter() throws Exception {
+        mockMvc.perform(get("/api/v1/biome/test_id")
+                        .content(MediaType.APPLICATION_JSON_VALUE))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(biomeService).findBiome("test_id", SortingCriteria.DESCENDING, SortingCriteria.ASCENDING);
+    }
+
+
+    @Test
+    @DisplayName("잘못된 값의 바이옴 포켓몬 정렬 기준 쿼리 스트링으로 요청하면 예외 응답을 반환한다.")
+    void handlesInvalidSortingCriteriaRequestParameter() throws Exception {
+        mockMvc.perform(get("/api/v1/biome/test_id")
+                        .content(MediaType.APPLICATION_JSON_VALUE)
+                        .param("boss", "ascc").param("wild", "desc"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.detail").value("Failed to convert 'boss' with value: 'ascc'"));
+    }
+}

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/service/BiomeServiceTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/service/BiomeServiceTest.java
@@ -1,10 +1,13 @@
 package com.pokerogue.helper.biome.service;
 
+import static com.pokerogue.helper.biome.service.NativePokemonComparator.ASCENDING;
+import static com.pokerogue.helper.biome.service.NativePokemonComparator.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pokerogue.environment.service.ServiceTest;
+import com.pokerogue.helper.biome.dto.BiomeAllPokemonResponse;
 import com.pokerogue.helper.biome.dto.BiomeDetailResponse;
 import com.pokerogue.helper.biome.dto.BiomeResponse;
 import com.pokerogue.helper.global.exception.ErrorMessage;
@@ -30,7 +33,7 @@ class BiomeServiceTest extends ServiceTest {
     @Test
     @DisplayName("단일 바이옴 정보를 불러온다")
     void findBiome() {
-        BiomeDetailResponse biomeDetailResponse = biomeService.findBiome("fairy_cave");
+        BiomeDetailResponse biomeDetailResponse = biomeService.findBiome("fairy_cave", ASCENDING, DESCENDING);
 
         assertAll(
                 () -> assertThat(biomeDetailResponse.id()).isEqualTo("fairy_cave"),
@@ -45,8 +48,25 @@ class BiomeServiceTest extends ServiceTest {
     @Test
     @DisplayName("해당 id의 바이옴이 없는 경우 예외를 발생시킨다")
     void notExistBiome() {
-        assertThatThrownBy(() -> biomeService.findBiome("test"))
+        assertThatThrownBy(() -> biomeService.findBiome("test", ASCENDING, DESCENDING))
                 .isInstanceOf(GlobalCustomException.class)
                 .hasMessage(ErrorMessage.BIOME_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("바이옴 포켓몬의 티어를 희귀도 순으로 정렬한다.")
+    void sortBiomeNativePokemons() {
+        String bossPokemonOrder = DESCENDING;
+        String wildPokemonOrder = ASCENDING;
+
+        BiomeDetailResponse biomeDetailResponse = biomeService.findBiome("fairy_cave", bossPokemonOrder,
+                wildPokemonOrder);
+
+        assertAll(() -> {
+            assertThat(biomeDetailResponse.wildPokemons()).extracting(BiomeAllPokemonResponse::tier)
+                    .containsExactly("보통", "드묾", "레어", "슈퍼 레어", "울트라 레어");
+            assertThat(biomeDetailResponse.bossPokemons()).extracting(BiomeAllPokemonResponse::tier)
+                    .containsExactly("슈퍼 울트라 레어 보스", "슈퍼 레어 보스", "레어 보스", "보스");
+        });
     }
 }

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/service/BiomeServiceTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/service/BiomeServiceTest.java
@@ -1,7 +1,7 @@
 package com.pokerogue.helper.biome.service;
 
-import static com.pokerogue.helper.biome.service.NativePokemonComparator.ASCENDING;
-import static com.pokerogue.helper.biome.service.NativePokemonComparator.DESCENDING;
+import static com.pokerogue.helper.global.constant.SortingCriteria.ASCENDING;
+import static com.pokerogue.helper.global.constant.SortingCriteria.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -10,6 +10,7 @@ import com.pokerogue.environment.service.ServiceTest;
 import com.pokerogue.helper.biome.dto.BiomeAllPokemonResponse;
 import com.pokerogue.helper.biome.dto.BiomeDetailResponse;
 import com.pokerogue.helper.biome.dto.BiomeResponse;
+import com.pokerogue.helper.global.constant.SortingCriteria;
 import com.pokerogue.helper.global.exception.ErrorMessage;
 import com.pokerogue.helper.global.exception.GlobalCustomException;
 import java.util.List;
@@ -56,8 +57,8 @@ class BiomeServiceTest extends ServiceTest {
     @Test
     @DisplayName("바이옴 포켓몬의 티어를 희귀도 순으로 정렬한다.")
     void sortBiomeNativePokemons() {
-        String bossPokemonOrder = DESCENDING;
-        String wildPokemonOrder = ASCENDING;
+        SortingCriteria bossPokemonOrder = DESCENDING;
+        SortingCriteria wildPokemonOrder = ASCENDING;
 
         BiomeDetailResponse biomeDetailResponse = biomeService.findBiome("fairy_cave", bossPokemonOrder,
                 wildPokemonOrder);

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/service/NativePokemonComparatorTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/service/NativePokemonComparatorTest.java
@@ -1,7 +1,7 @@
 package com.pokerogue.helper.biome.service;
 
-import static com.pokerogue.helper.biome.service.NativePokemonComparator.ASCENDING;
-import static com.pokerogue.helper.biome.service.NativePokemonComparator.DESCENDING;
+import static com.pokerogue.helper.global.constant.SortingCriteria.ASCENDING;
+import static com.pokerogue.helper.global.constant.SortingCriteria.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pokerogue.helper.biome.data.NativePokemon;

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/service/NativePokemonComparatorTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/biome/service/NativePokemonComparatorTest.java
@@ -1,0 +1,41 @@
+package com.pokerogue.helper.biome.service;
+
+import static com.pokerogue.helper.biome.service.NativePokemonComparator.ASCENDING;
+import static com.pokerogue.helper.biome.service.NativePokemonComparator.DESCENDING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.pokerogue.helper.biome.data.NativePokemon;
+import com.pokerogue.helper.biome.data.Tier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NativePokemonComparatorTest {
+
+    private final List<NativePokemon> nativePokemons = new ArrayList<>(List.of(
+            new NativePokemon(Tier.RARE, List.of("bulbasaur", "venusaur")),
+            new NativePokemon(Tier.COMMON, List.of("pikachu", "raichu")),
+            new NativePokemon(Tier.BOSS_RARE, List.of("charmander")),
+            new NativePokemon(Tier.BOSS_SUPER_RARE, List.of("roserade"))
+    ));
+
+    @Test
+    @DisplayName("바이옴 포켓몬을 티어의 희귀도가 낮은 순으로 정렬한다.")
+    void sortNativePokemonsAscending() {
+        Collections.sort(nativePokemons, NativePokemonComparator.of(ASCENDING));
+
+        assertThat(nativePokemons).extracting(NativePokemon::getTier)
+                .containsExactly(Tier.COMMON, Tier.RARE, Tier.BOSS_RARE, Tier.BOSS_SUPER_RARE);
+    }
+
+    @Test
+    @DisplayName("바이옴 포켓몬을 티어의 희귀도가 높은 순으로 정렬한다.")
+    void sortNativePokemonsDescending() {
+        Collections.sort(nativePokemons, NativePokemonComparator.of(DESCENDING));
+
+        assertThat(nativePokemons).extracting(NativePokemon::getTier)
+                .containsExactly(Tier.BOSS_SUPER_RARE, Tier.BOSS_RARE, Tier.RARE, Tier.COMMON);
+    }
+}

--- a/backend/pokerogue/src/test/java/com/pokerogue/helper/global/constant/SortingCriteriaTest.java
+++ b/backend/pokerogue/src/test/java/com/pokerogue/helper/global/constant/SortingCriteriaTest.java
@@ -1,0 +1,28 @@
+package com.pokerogue.helper.global.constant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SortingCriteriaTest {
+
+    @ParameterizedTest
+    @MethodSource("sortingCriteriaValues")
+    @DisplayName("문자열 값으로 SortingCriteria를 생성한다.")
+    void convertFrom(String value, SortingCriteria expected) {
+        SortingCriteria actual = SortingCriteria.convertFrom(value);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> sortingCriteriaValues() {
+        return Stream.of(
+                Arguments.of("desc", SortingCriteria.DESCENDING),
+                Arguments.of("asc", SortingCriteria.ASCENDING)
+        );
+    }
+}


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [ ] API 명세서가 업데이트 혹은 작성이 되어 있나요? -> 머지되고 작성할래요

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #362

- [x] 보스 포켓몬 희귀도 높은 순으로 티어 정렬
- [x] 요구사항에 관계 없이 동적으로 쿼리스트링을 사용해서 정렬

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

- [x] 있음
- [ ] 없음

이건 제안인데요! 쿼리 스트링으로 보스 포켓몬과 야생 포켓몬들 티어 정렬 기준을 받도록 api를 수정하면 어떨까요? 사용자 활동 로그를 바탕으로 정렬 순서도 고치기로 했던 걸로 기억하는데 정렬 같은 조건문은 요구사항에 따라 바뀌는 것보다 이렇게 설계하는게 더 유연해보여서 제안합니다 :)

`보스 포켓몬들에 대해 티어 높은 순으로 정렬`만 요구사항이었기 때문에 쿼리스트링 default 값을 보스 포켓몬은 desc, 야생 포켓몬은 asc로 설정해보았습니다. (하위 호환성 O)

별로라면 철회하겠읍니다..