### PR TITLE
[1.1.0/AN-FEAT] Splash 화면에서 포켓몬 데이터 캐싱 교체 전략 추가

### DIFF
--- a/android/app/src/main/java/poke/rogue/helper/PokeRogueHelperApp.kt
+++ b/android/app/src/main/java/poke/rogue/helper/PokeRogueHelperApp.kt
@@ -13,12 +13,12 @@ class PokeRogueHelperApp : Application() {
     override fun onCreate() {
         super.onCreate()
         initTimber()
-        DefaultDexRepository.init(this) // TODO : Koin 마이그레이션 다 끝나면 삭제!!
         startKoin {
             androidLogger(level = Level.DEBUG)
             androidContext(applicationContext)
             modules(appModule)
         }
+        DefaultDexRepository.init(this) // TODO : Koin 마이그레이션 다 끝나면 삭제!!
     }
 
     private fun initTimber() {

--- a/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/battle/BattleViewModel.kt
@@ -44,13 +44,15 @@ class BattleViewModel(
             battleRepository.savedWeatherStream(),
             weathers,
         ) { weather, weathers ->
-            if (weather == null || weathers.isEmpty()) return@combine null
-            if (weathers.any { it.id == weather.id }.not()) return@combine null
-            val selectedWeather = weathers.first { it.id == weather.id }
-            // update selected weather
-            _selectedState.value = selectedState.value.copy(weather = BattleSelectionUiState.Selected(selectedWeather))
-            // return position
-            weathers.indexOfFirst { it.id == weather.id }
+            if (weathers.isEmpty()) return@combine null
+            val weatherId = weather?.id ?: weathers.first().id
+            if (weathers.any { it.id == weatherId }.not()) return@combine null
+            val selectedWeather = weathers.first { it.id == weatherId }
+
+            _selectedState.value =
+                selectedState.value.copy(weather = BattleSelectionUiState.Selected(selectedWeather))
+
+            weathers.indexOfFirst { it.id == weatherId }
         }.filterNotNull()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/splash/PokemonIntroViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/splash/PokemonIntroViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import org.koin.mp.KoinPlatform.getKoin
 import poke.rogue.helper.analytics.AnalyticsLogger
 import poke.rogue.helper.data.repository.DexRepository
 import poke.rogue.helper.presentation.base.BaseViewModelFactory
@@ -31,6 +32,8 @@ class PokemonIntroViewModel(
                     coroutineScope {
                         launch { delay(MIN_SPLASH_TIME) }
                         launch { pokemonRepository.warmUp() }
+                        // TODO Koin 일괄적으로 적용 시 삭제 예정
+                        launch { getKoin().get<DexRepository>().warmUp() }
                     }
                 } catch (e: Exception) {
                     Timber.e(e)

--- a/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalDexDataSource.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalDexDataSource.kt
@@ -19,11 +19,18 @@ class LocalDexDataSource(
             logger.logError(it, "LocalDexDataSource - pokemons() 에서 발생")
         }.getOrThrow()
 
-    suspend fun savePokemons(pokemons: List<Pokemon>) =
+    suspend fun savePokemons(pokemons: List<Pokemon>): Unit =
         runCatching {
             pokemonDao.savePokemons(pokemons.map { it.toEntity() })
         }.onFailure {
             logger.logError(it, "LocalDexDataSource - savePokemons() 에서 발생")
+        }.getOrThrow()
+
+    suspend fun clear(): Unit =
+        runCatching {
+            pokemonDao.clear()
+        }.onFailure {
+            logger.logError(it, "LocalDexDataSource - clearPokemons() 에서 발생")
         }.getOrThrow()
 
     companion object {

--- a/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalVersionDataSource.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalVersionDataSource.kt
@@ -5,7 +5,7 @@ import poke.rogue.helper.local.datastore.VersionDataStore
 class LocalVersionDataSource(
     private val versionDataStore: VersionDataStore,
 ) {
-    fun databaseVersion() = versionDataStore.databaseVersion()
+    fun databaseVersionStream() = versionDataStore.databaseVersionStream()
 
     suspend fun saveDatabaseVersion(version: Int) = versionDataStore.saveDatabaseVersion(version)
 }

--- a/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalVersionDataSource.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/datasource/LocalVersionDataSource.kt
@@ -1,0 +1,11 @@
+package poke.rogue.helper.data.datasource
+
+import poke.rogue.helper.local.datastore.VersionDataStore
+
+class LocalVersionDataSource(
+    private val versionDataStore: VersionDataStore,
+) {
+    fun databaseVersion() = versionDataStore.databaseVersion()
+
+    suspend fun saveDatabaseVersion(version: Int) = versionDataStore.saveDatabaseVersion(version)
+}

--- a/android/data/src/main/java/poke/rogue/helper/data/datasource/RemoteVersionDataSource.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/datasource/RemoteVersionDataSource.kt
@@ -1,0 +1,17 @@
+package poke.rogue.helper.data.datasource
+
+import poke.rogue.helper.analytics.AnalyticsLogger
+import poke.rogue.helper.data.exception.getOrThrow
+import poke.rogue.helper.data.exception.onFailure
+import poke.rogue.helper.remote.service.VersionService
+
+class RemoteVersionDataSource(
+    private val versionService: VersionService,
+    private val logger: AnalyticsLogger,
+) {
+    suspend fun databaseVersion(): Int =
+        versionService.databaseVersion()
+            .onFailure {
+                logger.logError(throwable, "RemoteVersionDataSource - databaseVersion() 에서 발생")
+            }.getOrThrow().version
+}

--- a/android/data/src/main/java/poke/rogue/helper/data/di/DataSourceModule.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/di/DataSourceModule.kt
@@ -5,10 +5,12 @@ import org.koin.dsl.module
 import poke.rogue.helper.data.datasource.LocalBattleDataSource
 import poke.rogue.helper.data.datasource.LocalDexDataSource
 import poke.rogue.helper.data.datasource.LocalTypeDataSource
+import poke.rogue.helper.data.datasource.LocalVersionDataSource
 import poke.rogue.helper.data.datasource.RemoteAbilityDataSource
 import poke.rogue.helper.data.datasource.RemoteBattleDataSource
 import poke.rogue.helper.data.datasource.RemoteBiomeDataSource
 import poke.rogue.helper.data.datasource.RemoteDexDataSource
+import poke.rogue.helper.data.datasource.RemoteVersionDataSource
 
 internal val dataSourceModule
     get() =
@@ -16,9 +18,11 @@ internal val dataSourceModule
             singleOf(::LocalBattleDataSource)
             singleOf(::LocalDexDataSource)
             singleOf(::LocalTypeDataSource)
+            singleOf(::LocalVersionDataSource)
 
             singleOf(::RemoteBattleDataSource)
             singleOf(::RemoteAbilityDataSource)
             singleOf(::RemoteDexDataSource)
             singleOf(::RemoteBiomeDataSource)
+            singleOf(::RemoteVersionDataSource)
         }

--- a/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultDexRepository.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/repository/DefaultDexRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import org.koin.mp.KoinPlatform.getKoin
 import poke.rogue.helper.analytics.AnalyticsLogger
 import poke.rogue.helper.analytics.analyticsLogger
 import poke.rogue.helper.data.cache.GlideImageCacher
@@ -19,8 +20,6 @@ import poke.rogue.helper.data.model.PokemonDetail
 import poke.rogue.helper.data.model.PokemonFilter
 import poke.rogue.helper.data.model.PokemonSort
 import poke.rogue.helper.data.utils.logPokemonDetail
-import poke.rogue.helper.local.datastore.VersionDataStore
-import poke.rogue.helper.remote.injector.ServiceModule
 import poke.rogue.helper.stringmatcher.has
 
 class DefaultDexRepository(
@@ -144,8 +143,8 @@ class DefaultDexRepository(
                     GlideImageCacher.instance(),
                     DefaultBiomeRepository.instance(),
                     analyticsLogger(),
-                    LocalVersionDataSource(VersionDataStore(context)),
-                    RemoteVersionDataSource(ServiceModule.versionService(), analyticsLogger()),
+                    getKoin().get(),
+                    getKoin().get(),
                 )
         }
 

--- a/android/local/src/androidTest/java/poke/rogue/helper/local/dao/PokemonDaoTest.kt
+++ b/android/local/src/androidTest/java/poke/rogue/helper/local/dao/PokemonDaoTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName
 import org.koin.test.KoinTest
 import org.koin.test.get
 import poke.rogue.helper.local.di.testLocalModule
+import poke.rogue.helper.local.entity.PokemonEntity
 import poke.rogue.helper.local.entity.pokemonEntity
 import poke.rogue.helper.local.utils.KoinAndroidUnitTestRule
 
@@ -30,9 +31,29 @@ class PokemonDaoTest : KoinTest {
             // when
             dao.savePokemons(pokemons)
             val actual = dao.pokemons()
-            println(actual)
             // then
             val expect = pokemons
             actual shouldBe expect
+        }
+
+    @Test
+    @DisplayName("포켓몬 저장 후 저장 확인, 삭제 후 삭제 확인")
+    fun `test2`() =
+        runTest {
+            // given
+            val pokemons =
+                listOf(pokemonEntity(id = "1", name = "피카츄"), pokemonEntity(id = "2", name = "라이츄"))
+            // when
+            dao.savePokemons(pokemons)
+            val actual = dao.pokemons()
+            // then
+            val expect = pokemons
+            actual shouldBe expect
+            // when
+            dao.clear()
+            val actual2 = dao.pokemons()
+            // then
+            val expect2 = emptyList<PokemonEntity>()
+            actual2 shouldBe expect2
         }
 }

--- a/android/local/src/main/java/poke/rogue/helper/local/dao/PokemonDao.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/dao/PokemonDao.kt
@@ -16,6 +16,9 @@ interface PokemonDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun savePokemons(pokemons: List<PokemonEntity>)
 
+    @Query("DELETE FROM Pokemon")
+    suspend fun clear()
+
     companion object {
         fun instance(context: Context): PokemonDao {
             return PokeRogueDatabase.instance(context).pokemonDao()

--- a/android/local/src/main/java/poke/rogue/helper/local/datastore/VersionDataStore.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/datastore/VersionDataStore.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.map
 class VersionDataStore(private val context: Context) {
     private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = DATA_BASE_NAME)
 
-    fun databaseVersion(): Flow<Int?> =
+    fun databaseVersionStream(): Flow<Int?> =
         context.dataStore.data.map { preferences ->
             preferences[DATABASE_VERSION_KEY]
         }

--- a/android/local/src/main/java/poke/rogue/helper/local/datastore/VersionDataStore.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/datastore/VersionDataStore.kt
@@ -1,0 +1,30 @@
+package poke.rogue.helper.local.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class VersionDataStore(private val context: Context) {
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = DATA_BASE_NAME)
+
+    fun databaseVersion(): Flow<Int?> =
+        context.dataStore.data.map { preferences ->
+            preferences[DATABASE_VERSION_KEY]
+        }
+
+    suspend fun saveDatabaseVersion(version: Int) {
+        context.dataStore.edit { preferences ->
+            preferences[DATABASE_VERSION_KEY] = version
+        }
+    }
+
+    companion object {
+        private const val DATA_BASE_NAME = "datastore_version"
+        private val DATABASE_VERSION_KEY = intPreferencesKey("database_version")
+    }
+}

--- a/android/local/src/main/java/poke/rogue/helper/local/di/DataStoreModule.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/di/DataStoreModule.kt
@@ -3,9 +3,11 @@ package poke.rogue.helper.local.di
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import poke.rogue.helper.local.datastore.BattleDataStore
+import poke.rogue.helper.local.datastore.VersionDataStore
 
 internal val dataStoreModule
     get() =
         module {
             singleOf(::BattleDataStore)
+            singleOf(::VersionDataStore)
         }

--- a/android/remote/src/main/java/poke/rogue/helper/remote/di/ServiceModule.kt
+++ b/android/remote/src/main/java/poke/rogue/helper/remote/di/ServiceModule.kt
@@ -5,6 +5,7 @@ import poke.rogue.helper.remote.service.AbilityService
 import poke.rogue.helper.remote.service.BattleService
 import poke.rogue.helper.remote.service.BiomeService
 import poke.rogue.helper.remote.service.PokeDexService
+import poke.rogue.helper.remote.service.VersionService
 import retrofit2.Retrofit
 import retrofit2.create
 
@@ -15,4 +16,5 @@ internal val serviceModule
             single<BattleService> { get<Retrofit>().create() }
             single<BiomeService> { get<Retrofit>().create() }
             single<PokeDexService> { get<Retrofit>().create() }
+            single<VersionService> { get<Retrofit>().create() }
         }

--- a/android/remote/src/main/java/poke/rogue/helper/remote/dto/response/version/VersionResponse.kt
+++ b/android/remote/src/main/java/poke/rogue/helper/remote/dto/response/version/VersionResponse.kt
@@ -1,0 +1,5 @@
+package poke.rogue.helper.remote.dto.response.version
+
+data class VersionResponse(
+    val version: Int,
+)

--- a/android/remote/src/main/java/poke/rogue/helper/remote/dto/response/version/VersionResponse.kt
+++ b/android/remote/src/main/java/poke/rogue/helper/remote/dto/response/version/VersionResponse.kt
@@ -1,5 +1,10 @@
 package poke.rogue.helper.remote.dto.response.version
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class VersionResponse(
+    @SerialName("currentVersion")
     val version: Int,
 )

--- a/android/remote/src/main/java/poke/rogue/helper/remote/injector/ServiceModule.kt
+++ b/android/remote/src/main/java/poke/rogue/helper/remote/injector/ServiceModule.kt
@@ -4,6 +4,7 @@ import poke.rogue.helper.remote.service.AbilityService
 import poke.rogue.helper.remote.service.BattleService
 import poke.rogue.helper.remote.service.BiomeService
 import poke.rogue.helper.remote.service.PokeDexService
+import poke.rogue.helper.remote.service.VersionService
 import retrofit2.create
 
 object ServiceModule {
@@ -14,6 +15,8 @@ object ServiceModule {
     fun biomeService(): BiomeService = ServicePool.biomeService
 
     fun battleService(): BattleService = ServicePool.battleService
+
+    fun versionService(): VersionService = ServicePool.versionService
 
     private object ServicePool {
         val pokeDexService: PokeDexService by lazy {
@@ -26,6 +29,9 @@ object ServiceModule {
             RetrofitModule.retrofit().create()
         }
         val battleService: BattleService by lazy {
+            RetrofitModule.retrofit().create()
+        }
+        val versionService: VersionService by lazy {
             RetrofitModule.retrofit().create()
         }
     }

--- a/android/remote/src/main/java/poke/rogue/helper/remote/service/VersionService.kt
+++ b/android/remote/src/main/java/poke/rogue/helper/remote/service/VersionService.kt
@@ -1,0 +1,10 @@
+package poke.rogue.helper.remote.service
+
+import poke.rogue.helper.remote.dto.base.ApiResponse
+import poke.rogue.helper.remote.dto.response.version.VersionResponse
+import retrofit2.http.GET
+
+interface VersionService {
+    @GET("api/v1/database/version")
+    suspend fun databaseVersion(): ApiResponse<VersionResponse>
+}


### PR DESCRIPTION
- closed#381

## 작업한 내용
- [x] 데이터 베이스 버전 받아오는 api 연동
- [x] dataStore 에 데이터베이스 버전 저장
- [x] 버전 불일치 시 Room 에 저장된 포켓몬 데이터 리프레시

## PR 포인트
- 아직 서버쪽 api가 완성 안돼서 터짐! 서버 api 완성되면 머지 후 바아로 release할 예정!

## 🚀Next Feature
