### PR TITLE
[BE-INFRA] Tomcat thread pool 및 MongoDB connection pool 설정

### DIFF
--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/global/config/DataMongoDbConfig.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/global/config/DataMongoDbConfig.java
@@ -1,12 +1,20 @@
 package com.pokerogue.helper.global.config;
 
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.pokerogue.helper.biome.converter.TierConverter;
 import com.pokerogue.helper.move.converter.FlagConverter;
 import com.pokerogue.helper.move.converter.MoveCategoryConverter;
 import com.pokerogue.helper.move.converter.MoveTargetConverter;
 import com.pokerogue.helper.pokemon.converter.EvolutionItemConverter;
 import com.pokerogue.helper.type.converter.TypeReadConverter;
+
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
@@ -15,6 +23,9 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 @Configuration
 @EnableMongoRepositories(basePackages = {"com.pokerogue"})
 public class DataMongoDbConfig {
+
+    @Value("${spring.data.mongodb.uri}")
+    private String uri;
 
     @Bean
     public MongoCustomConversions customConversions() {
@@ -26,5 +37,20 @@ public class DataMongoDbConfig {
                 new FlagConverter(),
                 new TierConverter()
         ));
+    }
+
+    @Bean
+    public MongoClient mongoClient() {
+        ConnectionString connectionString = new ConnectionString(uri);
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .applyConnectionString(connectionString)
+                .applyToConnectionPoolSettings(builder -> builder
+                        .maxSize(10)
+                        .minSize(10)
+                        .maxWaitTime(2, TimeUnit.SECONDS)
+                )
+                .build();
+
+        return MongoClients.create(settings);
     }
 }

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/repository/PokemonInMemoryRepository.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/repository/PokemonInMemoryRepository.java
@@ -5,6 +5,8 @@ import static java.util.stream.Collectors.toMap;
 
 import com.pokerogue.helper.pokemon.data.Pokemon;
 import jakarta.annotation.PostConstruct;
+
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +38,7 @@ public class PokemonInMemoryRepository {
     public List<Pokemon> findAll() {
         return pokemons.values()
                 .stream()
+                .sorted(Comparator.comparingInt(Pokemon::getPokedexNumber))
                 .toList();
     }
 

--- a/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/service/PokemonService.java
+++ b/backend/pokerogue/src/main/java/com/pokerogue/helper/pokemon/service/PokemonService.java
@@ -20,6 +20,8 @@ import com.pokerogue.helper.pokemon.dto.PokemonResponse;
 import com.pokerogue.helper.pokemon.repository.PokemonInMemoryRepository;
 import com.pokerogue.helper.type.data.Type;
 import com.pokerogue.helper.type.dto.PokemonTypeResponse;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -78,7 +80,7 @@ public class PokemonService {
     }
 
     private List<PokemonAbilityResponse> createAbilityResponse(Pokemon pokemon) {
-        List<String> abilityIds = pokemon.getNormalAbilityIds();
+        List<String> abilityIds = new ArrayList<>(pokemon.getNormalAbilityIds());
         abilityIds.add(pokemon.getPassiveAbilityId());
         abilityIds.add(pokemon.getHiddenAbilityId());
 


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [x] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #419 

- [x] 목표 TPS 설정
- [x] k6를 통한 부하 테스트
- [x] Tomcat thread pool과 MongoDB connection pool을 설정

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)

> yml 파일 수정, 단일 포켓몬 정보 오류 수정, MongoConfig 수정

--------

## 목표 TPS, VUser 설정 및 부하 테스트 진행 방식
- 포켓로그 전세계 실시간 사용자 수: 약 6000명
- 1%를 웃도는 100명으로 VUser 및 TPS 설정
- k6로 100 VUser로 1분 간 부하 테스트
- 모든 데이터는 평균값으로 통계
- 서비스 핵심 기능 API로 테스트
## Tomcat thread pool
### 포켓몬 전체 목록 조회 API
<img width="420" alt="스크린샷 2024-10-24 오후 3 22 59" src="https://github.com/user-attachments/assets/b6a24320-9db6-401c-b80b-e02ab9a8004f">


### 배틀 결과 계산 API
<img width="932" alt="스크린샷 2024-10-24 오후 3 23 57" src="https://github.com/user-attachments/assets/a7bf336f-2934-43b9-b662-aeb8ecac5a36">

### 결론
- max thread 값은 10으로 설정한다. 5도 높은 TPS 값을 가지지만 CPU 사용율 측면에서 10이 유리하다.

## DB connection pool
- 포켓몬 목록 조회 API는 캐싱을 사용하기 때문에 배틀 API로만 성능을 측정한다.
- maxSize는 가장 TPS가 높은 10으로 설정한다.
- minSize와 maxSize를 동일하게 설정해서 connection pool 이점을 최대한 활용한다.
- waitingTime은 WAS 대기 시간보다 작은 값(2초)으로 설정한다. (default: 2분)
<img width="714" alt="스크린샷 2024-10-24 오후 3 28 00" src="https://github.com/user-attachments/assets/4d3984b8-d1fd-48e6-ac39-40cbfa2b18fd">

