### PR TITLE
[1.1.1/AN-feat] DB 마이그레이션 (Drop 방식 X)

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     alias(libs.plugins.kotlinx.serialization) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.room) apply false
     alias(libs.plugins.android.junit5) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics.plugin) apply false

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -114,6 +114,7 @@ androidx-test-extention-ktx = { group = "androidx.test.ext", name = "junit-ktx",
 junit5-android-test-core = { module = "de.mannodermaus.junit5:android-test-core", version.ref = "android-junit5-core" }
 junit5-android-test-runner = { module = "de.mannodermaus.junit5:android-test-runner", version.ref = "android-junit5-core" }
 android-mockk = { module = "io.mockk:mockk-android", version.ref = "mockk" }
+room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 
 # unit test
 kotlin-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
@@ -150,6 +151,7 @@ kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+room = { id = "androidx.room", version.ref = "room" }
 
 # google & firebase
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }

--- a/android/local/build.gradle.kts
+++ b/android/local/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.room)
 }
 
 android {
@@ -43,6 +44,13 @@ android {
             excludes += "win32-x86*/**"
         }
     }
+    sourceSets {
+        getByName("androidTest").assets.srcDir("$projectDir/schemas")
+    }
+}
+
+room {
+    schemaDirectory("$projectDir/schemas")
 }
 
 dependencies {
@@ -71,4 +79,5 @@ dependencies {
     androidTestImplementation(libs.kotest.runner.junit5)
     androidTestImplementation(libs.junit5.android.test.core)
     androidTestRuntimeOnly(libs.junit5.android.test.runner)
+    androidTestImplementation(libs.room.testing)
 }

--- a/android/local/schemas/poke.rogue.helper.local.db.PokeRogueDatabase/1.json
+++ b/android/local/schemas/poke.rogue.helper.local.db.PokeRogueDatabase/1.json
@@ -1,0 +1,112 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "734577a7ee599cdbfadbf26892c3d677",
+    "entities": [
+      {
+        "tableName": "Pokemon",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dexNumber` INTEGER NOT NULL, `formName` TEXT NOT NULL, `name` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `types` TEXT NOT NULL, `generation` INTEGER NOT NULL, `baseStat` INTEGER NOT NULL, `hp` INTEGER NOT NULL, `attack` INTEGER NOT NULL, `defense` INTEGER NOT NULL, `specialAttack` INTEGER NOT NULL, `specialDefense` INTEGER NOT NULL, `speed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dexNumber",
+            "columnName": "dexNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formName",
+            "columnName": "formName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "types",
+            "columnName": "types",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseStat",
+            "columnName": "baseStat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hp",
+            "columnName": "hp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attack",
+            "columnName": "attack",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defense",
+            "columnName": "defense",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specialAttack",
+            "columnName": "specialAttack",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specialDefense",
+            "columnName": "specialDefense",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '734577a7ee599cdbfadbf26892c3d677')"
+    ]
+  }
+}

--- a/android/local/schemas/poke.rogue.helper.local.db.PokeRogueDatabase/2.json
+++ b/android/local/schemas/poke.rogue.helper.local.db.PokeRogueDatabase/2.json
@@ -1,0 +1,119 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "15571e87f13db1101fb5cecf0fc2527f",
+    "entities": [
+      {
+        "tableName": "Pokemon",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dexNumber` INTEGER NOT NULL, `formName` TEXT NOT NULL, `name` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `backImageUrl` TEXT NOT NULL DEFAULT '', `types` TEXT NOT NULL, `generation` INTEGER NOT NULL, `baseStat` INTEGER NOT NULL, `hp` INTEGER NOT NULL, `attack` INTEGER NOT NULL, `defense` INTEGER NOT NULL, `specialAttack` INTEGER NOT NULL, `specialDefense` INTEGER NOT NULL, `speed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dexNumber",
+            "columnName": "dexNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formName",
+            "columnName": "formName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backImageUrl",
+            "columnName": "backImageUrl",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "types",
+            "columnName": "types",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseStat",
+            "columnName": "baseStat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hp",
+            "columnName": "hp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attack",
+            "columnName": "attack",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defense",
+            "columnName": "defense",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specialAttack",
+            "columnName": "specialAttack",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specialDefense",
+            "columnName": "specialDefense",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '15571e87f13db1101fb5cecf0fc2527f')"
+    ]
+  }
+}

--- a/android/local/schemas/poke.rogue.helper.local.db.PokeRogueDatabase/3.json
+++ b/android/local/schemas/poke.rogue.helper.local.db.PokeRogueDatabase/3.json
@@ -1,12 +1,12 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 2,
+    "version": 3,
     "identityHash": "15571e87f13db1101fb5cecf0fc2527f",
     "entities": [
       {
         "tableName": "Pokemon",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dexNumber` INTEGER NOT NULL, `formName` TEXT NOT NULL, `name` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `backImageUrl` TEXT NOT NULL, `types` TEXT NOT NULL, `generation` INTEGER NOT NULL, `baseStat` INTEGER NOT NULL, `hp` INTEGER NOT NULL, `attack` INTEGER NOT NULL, `defense` INTEGER NOT NULL, `specialAttack` INTEGER NOT NULL, `specialDefense` INTEGER NOT NULL, `speed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dexNumber` INTEGER NOT NULL, `formName` TEXT NOT NULL, `name` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `backImageUrl` TEXT NOT NULL DEFAULT '', `types` TEXT NOT NULL, `generation` INTEGER NOT NULL, `baseStat` INTEGER NOT NULL, `hp` INTEGER NOT NULL, `attack` INTEGER NOT NULL, `defense` INTEGER NOT NULL, `specialAttack` INTEGER NOT NULL, `specialDefense` INTEGER NOT NULL, `speed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -42,7 +42,8 @@
             "fieldPath": "backImageUrl",
             "columnName": "backImageUrl",
             "affinity": "TEXT",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "''"
           },
           {
             "fieldPath": "types",

--- a/android/local/src/androidTest/java/poke/rogue/helper/local/database/PokeRogueDatabaseMigrationTest.kt
+++ b/android/local/src/androidTest/java/poke/rogue/helper/local/database/PokeRogueDatabaseMigrationTest.kt
@@ -1,0 +1,89 @@
+package poke.rogue.helper.local.database
+
+import android.database.sqlite.SQLiteDatabase
+import androidx.core.content.contentValuesOf
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.platform.app.InstrumentationRegistry
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldBeEmpty
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.DisplayName
+import poke.rogue.helper.local.db.PokeRogueDatabase
+import poke.rogue.helper.local.entity.PokemonEntity
+import poke.rogue.helper.local.utils.migrationTestCase
+import poke.rogue.helper.local.utils.testContext
+import java.io.IOException
+
+/**
+ * [PokeRogueDatabase]의 AutoMigration 테스트
+ *
+ * ref: https://cs.android.com/androidx/architecture-components-samples/+/main:PersistenceMigrationsSample/app/src/androidTestRoom3/java/com/example/android/persistence/migrations/MigrationTest.java;l=58?q=MigrationTestHelper
+ * ref2: https://github.com/Ivy-Apps/ivy-wallet/blob/main/shared/data/core/src/androidTest/java/com/ivy/data/db/Migration128to129Test.kt#L29
+ * docs: https://developer.android.com/training/data-storage/room/migrating-db-versions#all-migrations-test
+ */
+class PokeRogueDatabaseMigrationTest {
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        PokeRogueDatabase::class.java
+    )
+
+    @Test
+    @Throws(IOException::class)
+    @DisplayName("버전 1에서 버전 2로 마이그레이션 데이터 무결성 테스트 - backImageUrl 추가")
+    fun test_migration1To2() = helper.migrationTestCase(
+        tableName = PokemonEntity.TABLE_NAME,
+        from = 1,
+        to = 2,
+        onBeforeMigration = {
+            val contentValue = contentValuesOf(
+                "id" to 1,
+                "dexNumber" to 25,
+                "formName" to "Normal",
+                "name" to "Pikachu",
+                "imageUrl" to "url_to_image",
+                "types" to "Electric",
+                "generation" to 1,
+                "baseStat" to 320,
+                "hp" to 35,
+                "attack" to 55,
+                "defense" to 40,
+                "specialAttack" to 50,
+                "specialDefense" to 50,
+                "speed" to 90,
+            )
+            insert(PokemonEntity.TABLE_NAME, SQLiteDatabase.CONFLICT_REPLACE, contentValue)
+        },
+        onAfterMigration = {
+            moveToFirst() shouldBe true
+            val backImageUrlIndex = getColumnIndex("backImageUrl")
+            val backImageUrl = getString(backImageUrlIndex)
+            backImageUrl.shouldBeEmpty()
+            moveToNext() shouldBe false
+        },
+    )
+
+    @Test
+    @DisplayName("모든 database 버전 마이그레이션 테스트")
+    @Throws(IOException::class)
+    fun test_migrateAll() {
+        // given
+        val dbName = "TEST_DB"
+        val oldestDbVersion = 1
+        // when : 가장 오래된 버전의 DB를 생성하고 닫음
+        helper.createDatabase(dbName, oldestDbVersion)
+            .close()
+
+        // then : 최신 버전 DB로 마이그레이션 후 검증
+        Room.databaseBuilder(
+            testContext,
+            PokeRogueDatabase::class.java,
+            "TEST_DB"
+        ).build().apply {
+            openHelper.writableDatabase.close()
+        }
+    }
+}
+

--- a/android/local/src/androidTest/java/poke/rogue/helper/local/database/PokeRogueDatabaseMigrationTest.kt
+++ b/android/local/src/androidTest/java/poke/rogue/helper/local/database/PokeRogueDatabaseMigrationTest.kt
@@ -25,45 +25,48 @@ import java.io.IOException
  */
 class PokeRogueDatabaseMigrationTest {
     @get:Rule
-    val helper = MigrationTestHelper(
-        InstrumentationRegistry.getInstrumentation(),
-        PokeRogueDatabase::class.java
-    )
+    val helper =
+        MigrationTestHelper(
+            InstrumentationRegistry.getInstrumentation(),
+            PokeRogueDatabase::class.java,
+        )
 
     @Test
     @Throws(IOException::class)
     @DisplayName("버전 1에서 버전 2로 마이그레이션 데이터 무결성 테스트 - backImageUrl 추가")
-    fun test_migration1To2() = helper.migrationTestCase(
-        tableName = PokemonEntity.TABLE_NAME,
-        from = 1,
-        to = 2,
-        onBeforeMigration = {
-            val contentValue = contentValuesOf(
-                "id" to 1,
-                "dexNumber" to 25,
-                "formName" to "Normal",
-                "name" to "Pikachu",
-                "imageUrl" to "url_to_image",
-                "types" to "Electric",
-                "generation" to 1,
-                "baseStat" to 320,
-                "hp" to 35,
-                "attack" to 55,
-                "defense" to 40,
-                "specialAttack" to 50,
-                "specialDefense" to 50,
-                "speed" to 90,
-            )
-            insert(PokemonEntity.TABLE_NAME, SQLiteDatabase.CONFLICT_REPLACE, contentValue)
-        },
-        onAfterMigration = {
-            moveToFirst() shouldBe true
-            val backImageUrlIndex = getColumnIndex("backImageUrl")
-            val backImageUrl = getString(backImageUrlIndex)
-            backImageUrl.shouldBeEmpty()
-            moveToNext() shouldBe false
-        },
-    )
+    fun test_migration1To2() =
+        helper.migrationTestCase(
+            tableName = PokemonEntity.TABLE_NAME,
+            from = 1,
+            to = 2,
+            onBeforeMigration = {
+                val contentValue =
+                    contentValuesOf(
+                        "id" to 1,
+                        "dexNumber" to 25,
+                        "formName" to "Normal",
+                        "name" to "Pikachu",
+                        "imageUrl" to "url_to_image",
+                        "types" to "Electric",
+                        "generation" to 1,
+                        "baseStat" to 320,
+                        "hp" to 35,
+                        "attack" to 55,
+                        "defense" to 40,
+                        "specialAttack" to 50,
+                        "specialDefense" to 50,
+                        "speed" to 90,
+                    )
+                insert(PokemonEntity.TABLE_NAME, SQLiteDatabase.CONFLICT_REPLACE, contentValue)
+            },
+            onAfterMigration = {
+                moveToFirst() shouldBe true
+                val backImageUrlIndex = getColumnIndex("backImageUrl")
+                val backImageUrl = getString(backImageUrlIndex)
+                backImageUrl.shouldBeEmpty()
+                moveToNext() shouldBe false
+            },
+        )
 
     @Test
     @DisplayName("모든 database 버전 마이그레이션 테스트")
@@ -80,10 +83,9 @@ class PokeRogueDatabaseMigrationTest {
         Room.databaseBuilder(
             testContext,
             PokeRogueDatabase::class.java,
-            "TEST_DB"
+            "TEST_DB",
         ).build().apply {
             openHelper.writableDatabase.close()
         }
     }
 }
-

--- a/android/local/src/androidTest/java/poke/rogue/helper/local/database/PokeRogueDatabaseMigrationTest.kt
+++ b/android/local/src/androidTest/java/poke/rogue/helper/local/database/PokeRogueDatabaseMigrationTest.kt
@@ -5,6 +5,8 @@ import androidx.core.content.contentValuesOf
 import androidx.room.Room
 import androidx.room.testing.MigrationTestHelper
 import androidx.test.platform.app.InstrumentationRegistry
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldNotBeEmpty
@@ -61,11 +63,11 @@ class PokeRogueDatabaseMigrationTest {
                 insert(PokemonEntity.TABLE_NAME, SQLiteDatabase.CONFLICT_REPLACE, contentValue)
             },
             onAfterMigration = {
-                moveToFirst() shouldBe true
+                moveToFirst().shouldBeTrue()
                 val backImageUrlIndex = getColumnIndex("backImageUrl")
                 val backImageUrl = getString(backImageUrlIndex)
                 backImageUrl.shouldBeEmpty()
-                moveToNext() shouldBe false
+                moveToNext().shouldBeFalse()
             },
             migrations = PokeRogueDatabase.MIGRATIONS,
         )
@@ -100,12 +102,11 @@ class PokeRogueDatabaseMigrationTest {
                 insert(PokemonEntity.TABLE_NAME, SQLiteDatabase.CONFLICT_REPLACE, contentValue)
             },
             onAfterMigration = {
-                moveToFirst() shouldBe true
-                val backImageUrlIndex = getColumnIndex("backImageUrl")
-                val backImageUrl = getString(backImageUrlIndex)
-                backImageUrl.shouldNotBeEmpty()
-                backImageUrl shouldBe "testUrl"
-                moveToNext() shouldBe false
+                moveToFirst().shouldBeTrue()
+                val pokemonName = getString(getColumnIndex("name"))
+                pokemonName.shouldNotBeEmpty()
+                pokemonName shouldBe "Pikachu"
+                moveToNext().shouldBeFalse()
             },
             migrations = PokeRogueDatabase.MIGRATIONS,
         )

--- a/android/local/src/androidTest/java/poke/rogue/helper/local/utils/MigrationTestUtils.kt
+++ b/android/local/src/androidTest/java/poke/rogue/helper/local/utils/MigrationTestUtils.kt
@@ -26,12 +26,13 @@ fun MigrationTestHelper.migrationTestCase(
     }
 
     // When
-    val newDb = runMigrationsAndValidate(
-        testDbName,
-        to,
-        true,
-        *migrations,
-    )
+    val newDb =
+        runMigrationsAndValidate(
+            testDbName,
+            to,
+            true,
+            *migrations,
+        )
 
     // Then
     newDb.query("SELECT * FROM $tableName").apply {

--- a/android/local/src/androidTest/java/poke/rogue/helper/local/utils/MigrationTestUtils.kt
+++ b/android/local/src/androidTest/java/poke/rogue/helper/local/utils/MigrationTestUtils.kt
@@ -1,0 +1,41 @@
+package poke.rogue.helper.local.utils
+
+import android.database.Cursor
+import androidx.room.migration.Migration
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * [MigrationTestHelper]를 사용하여 마이그레이션 테스트를 BDD 스타일로 작성하기 위한 확장 함수
+ *
+ * ref: https://github.com/Ivy-Apps/ivy-wallet/blob/main/shared/data/core/src/androidTest/java/com/ivy/data/db/Migration128to129Test.kt#L29
+ * */
+fun MigrationTestHelper.migrationTestCase(
+    tableName: String,
+    from: Int,
+    to: Int,
+    onBeforeMigration: SupportSQLiteDatabase.() -> Unit,
+    onAfterMigration: Cursor.() -> Unit,
+    testDbName: String = "test-db",
+    vararg migrations: Migration,
+) {
+    // Given
+    createDatabase(testDbName, from).apply {
+        onBeforeMigration()
+        close()
+    }
+
+    // When
+    val newDb = runMigrationsAndValidate(
+        testDbName,
+        to,
+        true,
+        *migrations,
+    )
+
+    // Then
+    newDb.query("SELECT * FROM $tableName").apply {
+        onAfterMigration()
+    }
+    newDb.close()
+}

--- a/android/local/src/main/java/poke/rogue/helper/local/db/PokeRogueDatabase.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/db/PokeRogueDatabase.kt
@@ -5,13 +5,14 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import poke.rogue.helper.local.converter.PokemonTypeConverters
 import poke.rogue.helper.local.dao.PokemonDao
+import poke.rogue.helper.local.db.migrations.Migration1To2
 import poke.rogue.helper.local.entity.PokemonEntity
 
 @Database(
     entities = [PokemonEntity::class],
-    version = 2,
+    version = 3,
     autoMigrations = [
-        AutoMigration(from = 1, to = 2),
+        AutoMigration(from = 2, to = 3),
     ],
 )
 @androidx.room.TypeConverters(PokemonTypeConverters::class)
@@ -20,5 +21,6 @@ abstract class PokeRogueDatabase : RoomDatabase() {
 
     companion object {
         const val DATABASE_NAME = "pokemon_helper.db"
+        val MIGRATIONS = arrayOf(Migration1To2)
     }
 }

--- a/android/local/src/main/java/poke/rogue/helper/local/db/PokeRogueDatabase.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/db/PokeRogueDatabase.kt
@@ -1,5 +1,6 @@
 package poke.rogue.helper.local.db
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import poke.rogue.helper.local.converter.PokemonTypeConverters
@@ -9,6 +10,9 @@ import poke.rogue.helper.local.entity.PokemonEntity
 @Database(
     entities = [PokemonEntity::class],
     version = 2,
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2)
+    ]
 )
 @androidx.room.TypeConverters(PokemonTypeConverters::class)
 abstract class PokeRogueDatabase : RoomDatabase() {

--- a/android/local/src/main/java/poke/rogue/helper/local/db/PokeRogueDatabase.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/db/PokeRogueDatabase.kt
@@ -11,8 +11,8 @@ import poke.rogue.helper.local.entity.PokemonEntity
     entities = [PokemonEntity::class],
     version = 2,
     autoMigrations = [
-        AutoMigration(from = 1, to = 2)
-    ]
+        AutoMigration(from = 1, to = 2),
+    ],
 )
 @androidx.room.TypeConverters(PokemonTypeConverters::class)
 abstract class PokeRogueDatabase : RoomDatabase() {

--- a/android/local/src/main/java/poke/rogue/helper/local/db/migrations/Migration1To2.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/db/migrations/Migration1To2.kt
@@ -1,0 +1,11 @@
+package poke.rogue.helper.local.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val Migration1To2 =
+    object : Migration(1, 2) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("ALTER TABLE Pokemon ADD COLUMN backImageUrl TEXT NOT NULL DEFAULT ''")
+        }
+    }

--- a/android/local/src/main/java/poke/rogue/helper/local/di/DataBaseModule.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/di/DataBaseModule.kt
@@ -12,7 +12,6 @@ internal val dataBaseModule
                     get(),
                     PokeRogueDatabase::class.java,
                     PokeRogueDatabase.DATABASE_NAME,
-                ).fallbackToDestructiveMigration()
-                    .build()
+                ).build()
             }
         }

--- a/android/local/src/main/java/poke/rogue/helper/local/di/DataBaseModule.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/di/DataBaseModule.kt
@@ -12,6 +12,7 @@ internal val dataBaseModule
                     get(),
                     PokeRogueDatabase::class.java,
                     PokeRogueDatabase.DATABASE_NAME,
-                ).build()
+                ).fallbackToDestructiveMigration()
+                    .build()
             }
         }

--- a/android/local/src/main/java/poke/rogue/helper/local/di/DataBaseModule.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/di/DataBaseModule.kt
@@ -12,6 +12,7 @@ internal val dataBaseModule
                     get(),
                     PokeRogueDatabase::class.java,
                     PokeRogueDatabase.DATABASE_NAME,
-                ).build()
+                ).addMigrations(*PokeRogueDatabase.MIGRATIONS)
+                    .build()
             }
         }

--- a/android/local/src/main/java/poke/rogue/helper/local/entity/PokemonEntity.kt
+++ b/android/local/src/main/java/poke/rogue/helper/local/entity/PokemonEntity.kt
@@ -1,15 +1,18 @@
 package poke.rogue.helper.local.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import poke.rogue.helper.local.entity.PokemonEntity.Companion.TABLE_NAME
 
-@Entity(tableName = "Pokemon")
+@Entity(tableName = TABLE_NAME)
 data class PokemonEntity(
     @PrimaryKey val id: String,
     val dexNumber: Long,
     val formName: String,
     val name: String,
     val imageUrl: String,
+    @ColumnInfo(defaultValue = "")
     val backImageUrl: String,
     val types: Set<String>,
     val generation: Int,
@@ -20,4 +23,8 @@ data class PokemonEntity(
     val specialAttack: Int,
     val specialDefense: Int,
     val speed: Int,
-)
+) {
+    companion object {
+        const val TABLE_NAME = "Pokemon"
+    }
+}


### PR DESCRIPTION
# 데모데이 때 특정 기기에서 오류가 발생한 이유

데모데이 때 `Migration_1_to_2 Exception`이 문제가 생겼던 이유는 제가 Koin 적용할 때 [fallbackToDestructiveMigrationFrom()](https://developer.android.com/reference/kotlin/androidx/room/RoomDatabase.Builder#fallbacktodestructivemigrationfrom)을 추가를 안해줘서 그렇습니다.. 하하 미안합니다 😢  

## 작업한 내용
- DB Auto Migration 작업 및 Migration 테스트 
- DB Migration 테스트 

## `fallbackToDestructiveMigration` 에서 Auto Migration 으로 변경한 이유

`fallbackToDestructiveMigration` 은 db가 마이그레이션에 실패하면 Drop하고 다시 만드는 함수입니다.(심지가 저번에도 설명해주었지만)
따라서, DB 마이그레이션한 이력이 남지 않습니다.  과거 DB 버전으로 회귀하고 싶을 경우와 같이 버전 기록이 필요한 경우가 생기면, 과거 PR 이력들을 모두 찾지 않는 이상 불가능합니다.

이제 시간에 쫓겨 작업하지 않아도 되니, Migration 작업이 조금 번거로워도 더 좋은 프로젝트가 되기 위해 제안해봅니다!

## DB Migration 테스트 

> 디비 마이그레이션 테스트에 대한 이해를 위해 간단하게 작성해둘게여
> 테스트 코드를 작성하는 방법은 작성한 코드를 봐주세여~

`room-test`에서 지원하는 `MigrationTestHelper` 가 scheme history를 기반으로 마이그레이션 테스트합니다.
따라서, `androidTest/schemas/../pokeRogueDatabase/(dbVersion).json` 에  이전 디비 버전의 scheme 들이 있어야합니다. 

그리고, 마이그레이션 테스트에는 다음과 같이 2가지 종류의 테스트가 있다고 합니다.

### 1) 단일 마이그레이션 테스트 (데이터 무결성 테스트)

DB 버전을 올려도 이전 데이터가 손상이 일어나지 않는지를 테스트합니다!

```kotlin
// from: db version 1
data class User(
   @PrimaryKey val id: String,
    val name: String,
)

// to: db version 2

data class User(
   @PrimaryKey val id: String,
    val name: String,
    @ColumnInfo(defaultValue = -1)    
    val age: Int,
)
```

위와 같이 User 에 age 라는 새로운 컬럼이 추가되었으면 2가지 테스트를 합니다.  

1. 기존 데이터가 손상되었는가?
2. 새로운 컬럼에 default 값이 들어가는가

### 2) 전체 마이그레이션 테스트

가장 오래된 db 버전이 1이고, 가장 최신 db 버전이 10이라고 가정했을 때  
1 에서 10으로 마이그레이션하는데 문제가 없는지 확인하는 테스트입니다!  

## 참고자료 

> https://github.com/woowacourse-teams/2024-pokerogue-helper/pull/355 이 큰 도움이 됐어요 땡큐 심지 👍👍  

프로젝트 코드에도 남겼지만 작업하면서 참고한 자료들 입니다.

[db 마이그레이션 공식문서](https://developer.android.com/training/data-storage/room/migrating-db-versions#all-migrations-test)  

[ivy 프로젝트 db 마이그레이션 테스트](https://github.com/Ivy-Apps/ivy-wallet/blob/main/shared/data/core/src/androidTest/java/com/ivy/data/db/Migration128to129Test.kt#L29)

[안드로이드 공식 샘플 코드](https://cs.android.com/androidx/architecture-components-samples/+/main:PersistenceMigrationsSample/app/src/androidTestRoom3/java/com/example/android/persistence/migrations/MigrationTest.java)

## 🚀Next Feature

- Instrumentation Test 자동화 
- Robolectric Fragment Test 버그 수정