### PR TITLE
[ALL] 워크플로우 파일 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/새로운-기능.md
+++ b/.github/ISSUE_TEMPLATE/새로운-기능.md
@@ -2,7 +2,7 @@
 name: 새로운 기능
 about: feat
 title: "[BE-FEAT]"
-labels: BE_FEAT
+labels: ''
 assignees: ''
 
 ---
@@ -14,6 +14,11 @@ assignees: ''
 ✨ Task
 ---
 - [ ] 기능 세부 요구 사항에 대해 작성 해주세요.
+
+✨ Client
+---
+- [ ] 클라이언트에게 전달되는 Dto가 바꼈나요?
+- [ ] 클라이언트가 사용하게 될 값(value)가 바꼈나요?
 
 ✨ Time
 ---

--- a/.github/workflows/Auto_Close_Issue.yml
+++ b/.github/workflows/Auto_Close_Issue.yml
@@ -1,0 +1,25 @@
+name: Close Linked Issues on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract issue numbers from PR body
+        id: extract_issues
+        run: |
+          ISSUES=$(echo "${{ github.event.pull_request.body }}" | grep -oE '#[0-9]+' | tr -d '#')
+          echo "issues=${ISSUES}" >> $GITHUB_OUTPUT
+
+      - name: Close linked issues
+        if: ${{ steps.extract_issues.outputs.issues }}
+        uses: peter-evans/close-issue@v3
+        with:
+          issue-number: ${{ steps.extract_issues.outputs.issues }}
+          comment: 'This issue has been closed because the related PR was merged.'

--- a/.github/workflows/Backend_Auto_Create_PR.yml
+++ b/.github/workflows/Backend_Auto_Create_PR.yml
@@ -1,0 +1,84 @@
+name: Create PR from Branch
+
+on:
+  push:
+    branches:
+      - 'be/**'
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Get Issue Number
+        id: get_issue
+        run: |
+          BRANCH_NAME=${GITHUB_REF_NAME}
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
+          ISSUE_NUMBER=$(echo "${BRANCH_NAME}" | grep -oP '#\K\d+')
+          echo "ISSUE_NUMBER=${ISSUE_NUMBER}" >> $GITHUB_ENV
+
+      - name: Get Issue Details
+        id: get_issue_details
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_DATA=$(gh issue view "${ISSUE_NUMBER}" --json title,body,assignees,labels --jq '{title: .title, body: .body, assignees: [.assignees[].login], labels: [.labels[].name]}')
+          echo "ISSUE_DATA=${ISSUE_DATA}" >> $GITHUB_ENV
+
+      - name: Check for Existing PR
+        id: check_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE_BRANCH="be/develop"
+          echo "BASE_BRANCH=${BASE_BRANCH}" >> $GITHUB_ENV
+          EXISTING_PR=$(gh pr list --state open --base "${BASE_BRANCH}" --head "${BRANCH_NAME}" --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "An existing PR #${EXISTING_PR} already exists for this issue and branch. Exiting..."
+            echo "EXISTING_PR=true" >> $GITHUB_ENV
+            exit 0
+          else
+            echo "EXISTING_PR=false" >> $GITHUB_ENV
+          fi
+
+      - name: Create Pull Request
+        if: env.EXISTING_PR == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ASSIGNEES=$(echo "${ISSUE_DATA}" | jq -r '.assignees | join(",")')
+          LABELS=$(echo "${ISSUE_DATA}" | jq -r '.labels | join(",")')
+          TEAM_MEMBERS=("unifolio0" "jongmee" "dwax1324" "jinchiim")
+          IFS=', ' read -r -a ASSIGNEE_ARRAY <<< "${ASSIGNEES}"
+          REVIEWERS=()
+          for MEMBER in "${TEAM_MEMBERS[@]}"; do
+            if [[ ! " ${ASSIGNEE_ARRAY[@]} " =~ " ${MEMBER} " ]]; then
+              REVIEWERS+=("${MEMBER}")
+            fi
+          done
+          REVIEWER_LIST=$(IFS=', '; echo "${REVIEWERS[*]}")
+          ISSUE_TITLE=$(echo "${ISSUE_DATA}" | jq -r '.title')
+          ISSUE_BODY=$(echo "${ISSUE_DATA}" | jq -r '.body')
+          TASK_ITEMS=$(echo "${ISSUE_BODY}" | awk '/✨ Task/,/✨ Time/' | sed '1d;$d')
+          PR_BODY=$(cat <<EOM
+          ## 🍄 PR 확인 사항
+          
+          PR이 다음 요구 사항을 충족하는지 확인하세요. :
+          
+            - [ ] API 명세서가 업데이트 혹은 작성이 되어 있나요?
+          
+          ## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
+            > Issue Number: #${ISSUE_NUMBER}
+          
+            ${TASK_ITEMS}
+          
+          ## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)
+          
+          - [ ] 있음
+          - [ ] 없음
+          EOM
+          )
+          gh pr create --base "${BASE_BRANCH}" --head "${BRANCH_NAME}" --title "${ISSUE_TITLE}" --body "${PR_BODY}" --assignee "${ASSIGNEES}" --reviewer "${REVIEWER_LIST}" --label "${LABELS}"

--- a/.github/workflows/Issue_Checkbox_Notification.yml
+++ b/.github/workflows/Issue_Checkbox_Notification.yml
@@ -1,0 +1,58 @@
+name: Notification Checkbox Issue
+
+on:
+  issues:
+    types: [ opened, edited ]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if Client Checkboxes are Checked
+        id: check-client-checkbox
+        run: |
+          issue_body="${{ github.event.issue.body }}"
+          client_section=$(echo "${issue_body}" | sed -n '/✨ Client/,/Time/p')
+          
+          if echo "${client_section}" | grep -q "\- \[x\]"; then
+            echo "client_checked=true" >> $GITHUB_ENV
+          else
+            echo "client_checked=false" >> $GITHUB_ENV
+          fi
+
+      - name: Send Discord Notification
+        if: env.client_checked == 'true'
+        env:
+          WEB_HOOK: ${{ secrets.AN_DISCORD_WEB_HOOK }}
+          AVATAR_URL: ${{ secrets.ISSUE_NOTI_AVATAR_URL }}
+        run: |
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_URL="${{ github.event.issue.html_url }}"
+          AUTHOR_NAME="${{ github.event.issue.user.login }}"
+          AUTHOR_AVATAR="${{ github.event.issue.user.avatar_url }}"
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "$(jq -n \
+                     --arg content "API 관련 수정이 있습니다!" \
+                     --arg username "팽도리" \
+                     --arg avatar_url "$AVATAR_URL" \
+                     --arg issue_title "$ISSUE_TITLE" \
+                     --arg issue_url "$ISSUE_URL" \
+                     --arg author_name "$AUTHOR_NAME" \
+                     --arg author_avatar "$AUTHOR_AVATAR" \
+                     '{
+                        content: $content, 
+                        username: $username, 
+                        avatar_url: $avatar_url, 
+                        embeds: [{
+                          title: $issue_title, 
+                          url: $issue_url,
+                          author: {
+                            name: $author_name,
+                            icon_url: $author_avatar
+                          }
+                        }] 
+                     }'
+                  )" \
+               "$WEB_HOOK"


### PR DESCRIPTION
## 🍄 PR 확인 사항
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [x] API 명세서가 업데이트 혹은 작성이 되어 있나요?

## 현재 작업은 어떤 이슈를 해결한 것인지 설명해주세요.
> Issue Number: #445 

- [x] 백엔드 자동 pr 생성
- [x] 비디폴트 pr 이슈 자동 close
- [x] 백엔드 api변경 이슈 디스코드로 알림 전송

## 기존 코드에서 변경된 점이 있다면 설명해주세요. (추가 X)
[BE-FEAT] 이슈 템플릿 수정했습니다!

전부 러프하게 작성해서 제대로 예외 처리가 안 되어 있어 차차 리팩토링이 필요하긴 합니다.
추가로 이슈 close파일이랑 pr생성 파일은 해당 브랜치에 존재하지 않으면 작동을 안 해서 be/develop과 an/develop에도 추가해야 할 듯 합니다.

### 백엔드 자동 pr 생성 작동 방식
be/ 로 시작되는 브랜치에 push가 발생하면 해당 브랜치의 이름에서 이슈 번호를 추출해 pr을 만듭니다. 이때 해당 이슈의 Task 항목부터 Time항목 전까지 가져와서 pr에 넣습니다.
지금은 be/로 시작하면 무조건 작동하기 때문에 be/feat, be/refactor ,... 과 같은 브랜치에서만 push가 발생하면 작동하도록 수정할 예정입니다.

### 비디폴트 pr 이슈 자동 close
pr의 내용에서 #뒤에 있는 숫자에 해당하는 이슈들을 자동으로 close합니다. 이 워크플로우는 pr이 머지되거나 close되면 동작합니다.

### 백엔드 api변경 이슈 디스코드로 알림 전송
백엔드 이슈 템플릿에서 Client 항목에 있는 체크박스 중 하나라도 체크가 되면 디스코드 안드 채널로 알림을 보냅니다.
이슈가 생성되거나 수정되면 동작합니다.
지금은 이슈가 생성되면 무조건 동작합니다. 다만 이슈에 Client항목이 없으면 동작하지 않기 때문에 큰 문제는 없을 듯 합니다.