### PR TITLE
[1.2.0/AN-UI] PokemonList 스크롤 최상단으로 올리는 버튼

### DIFF
--- a/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListActivity.kt
@@ -2,8 +2,15 @@ package poke.rogue.helper.presentation.dex
 
 import android.content.res.Configuration
 import android.os.Bundle
+import android.view.animation.AnimationUtils
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import poke.rogue.helper.R
 import poke.rogue.helper.databinding.ActivityPokemonListBinding
@@ -56,6 +63,53 @@ class PokemonListActivity :
                     spanCount = spanCount,
                     spacing = 9.dp,
                     includeEdge = false,
+                ),
+            )
+            addOnScrollListener(pokemonListScrollListener())
+        }
+    }
+
+    private fun pokemonListScrollListener() =
+        object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(
+                recyclerView: RecyclerView,
+                dx: Int,
+                dy: Int,
+            ) {
+                if (!recyclerView.canScrollVertically(-1)) {
+                    hideScrollUpButton()
+                } else {
+                    showScrollUpButton()
+                }
+            }
+
+            override fun onScrollStateChanged(
+                recyclerView: RecyclerView,
+                newState: Int,
+            ) {
+                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    hideScrollUpButton()
+                }
+            }
+        }
+
+    private fun showScrollUpButton() {
+        val scrollUpButton = binding.btnPokeListScrollUp
+        if (scrollUpButton.isVisible) return
+        scrollUpButton.isVisible = true
+        scrollUpButton.startAnimation(AnimationUtils.loadAnimation(this, R.anim.fade_in))
+    }
+
+    private fun hideScrollUpButton() {
+        val scrollUpButton = binding.btnPokeListScrollUp
+        if (scrollUpButton.isGone) return
+        lifecycleScope.launch {
+            delay(300L)
+            scrollUpButton.isGone = true
+            scrollUpButton.startAnimation(
+                AnimationUtils.loadAnimation(
+                    this@PokemonListActivity,
+                    R.anim.fade_out,
                 ),
             )
         }
@@ -128,6 +182,10 @@ class PokemonListActivity :
     }
 
     private fun initListeners() {
+        binding.btnPokeListScrollUp.setOnClickListener {
+            binding.rvPokemonList.scrollToPosition(0)
+            binding.appBarPokemonList.setExpanded(true, true)
+        }
         binding.root.setOnClickListener {
             hideKeyboard()
         }

--- a/android/app/src/main/res/anim/fade_in.xml
+++ b/android/app/src/main/res/anim/fade_in.xml
@@ -1,0 +1,4 @@
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="300"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0" />

--- a/android/app/src/main/res/anim/fade_out.xml
+++ b/android/app/src/main/res/anim/fade_out.xml
@@ -1,0 +1,4 @@
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="300"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0" />

--- a/android/app/src/main/res/drawable/ic_arrow_up_24.xml
+++ b/android/app/src/main/res/drawable/ic_arrow_up_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z"/>
+    
+</vector>

--- a/android/app/src/main/res/layout/activity_pokemon_list.xml
+++ b/android/app/src/main/res/layout/activity_pokemon_list.xml
@@ -154,5 +154,20 @@
                 app:layout_constraintStart_toStartOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/btn_poke_list_scroll_up"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:backgroundTint="@color/poke_grey_60"
+            android:contentDescription="Scroll Up"
+            android:gravity="center"
+            android:src="@drawable/ic_arrow_up_24"
+            android:visibility="gone"
+            app:fabCustomSize="44dp"
+            app:iconSize="12dp"
+            app:layout_anchor="@id/rv_pokemon_list"
+            app:layout_anchorGravity="bottom|end"
+            tools:visibility="visible" />
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>


### PR DESCRIPTION
- closed #475

## 작업 영상

https://github.com/user-attachments/assets/8a919d1f-c1f8-4ce7-bc32-bb6d33f50a11


## 작업한 내용
- [x] PokemonList 스크롤 최상단으로 올리는 버튼 ui 구현
- [x] 스크롤이 가능할 때: 버튼 show
- [x] 스크롤이 완전히 끝나고 `300ms` 후 gone
- [x] 버튼이 show 할 때 fade-in 애니메이션
- [x] 버튼이 hide 할 때 fade-out 애니메이션

## PR 포인트

1) 리사이클러뷰 스크롤 시 이벤트 처리를 ViewModel에서 담당할까 했지만, 서버와의 통신이나 검증 로직이 들어갈 일이 없다 판단하여 Activity 에 버튼 show/hide 로직을 작성하였습니다!

2) 스크롤이 완전히 종료 후 `300ms` 정도 후에 버튼을 hide 처리했습니다. 시간이 너무 짧거나 길면 말씀해주세요 😉  
 에뮬레이터로 테스트하면 너무 빨리 없어져보일 수도?!

## 🚀Next Feature
- 포켓몬 폼 형태 이름 중복해서 보이는 문제 해결
- 버튼 클릭 시 Scale UP 애니메이션 구현
