### PR TITLE
[1.2.0/AN-Config] Project 단 build.gradle.kts 에서 buildScript 문 삭제

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,19 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-
-    dependencies {
-        classpath(libs.kotlin.gradleplugin)
-        classpath(libs.agp)
-        classpath(libs.ktlint)
-    }
-}
-
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -61,12 +61,10 @@ mockk = "1.13.9"
 firebaseCrashlyticsBuildtools = "3.0.2"
 
 [libraries]
-agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 
 # kotlin
 balloon = { module = "com.github.skydoves:balloon", version.ref = "balloon" }
 kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
-kotlin-gradleplugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 
 # koin
@@ -127,7 +125,6 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-webserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 # third party
-ktlint = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 okhttp = { module = "com.squareup.okhttp3:okhttp" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor" }


### PR DESCRIPTION
## 작업한 내용

- 불필요한 legacy인 `buildScript`를 걷어냄

## 작업 설명

![image](https://github.com/user-attachments/assets/bfb33954-824a-4b63-bdbc-79a1b6f94ddc)

- 우리 프로젝트 Gradle 버전: 8.4 

Gradle 7.0 이상에서는 `buldScript`  대신 `plugins`와 `pluginManagement` 를 사용해서 플러그인 의존성을 관리하라고 나와있습니다.  
제가 초기에 프로젝트 설정할 때, 이에 대한 지식이 부족해서 2가지 방식 모두 중복 적용했었네요 🥲  

두 방식의 차이를 궁금해하실까봐 간략하게 설명 남기겠습니다.

### buldScript 방식(legacy)

```kotlin
buildscript {
    repositories {
        google()
        mavenCentral()
    }
    dependencies {
          classPath(libs.agp)
    }
}

apply(plugin = "com.android.application") // 플러그인 수동 적용
```

`buildscript`는 Gradle이 빌드 스크립트를 실행하기 전에, 필요한 플러그인 의존성을 먼저 클래스패스에 추가하는 역할을 했습니다.
다운 받을 `repository`와 classPath를 지정해준 후, apply를 통해 플러그인을 적용했습니다.

### plugins 방식 + version catalog

```kotlin
// settings.gradle.kts
pluginManagement {
    repositories {
        google()
        mavenCentral()
        gradlePluginPortal()
    }
}
// build.gradle.kts
plugins {
    alias(libs.plugins.android.application) apply false
}
```
-  `pluginManagement`를 통해 plugin을 어느 저장소에서 다운받고 가져올지 지정
- `plugins` 을 활용하면 Gradle의 플러그인 시스템과 통합되어, 플러그인의 의존성 로딩과 적용을 통합할 수 있음

### referenece

[Gradle 공식문서 - Using Plugins](https://docs.gradle.org/current/userguide/plugins.html)

## 🚀Next Feature
- 버튼 스케일 업/다운 애니메이션