### PR TITLE
[1.2.1/ AN-CONFIG] :stringmatcher java 설정 변경

### DIFF
--- a/android/stringmatcher/build.gradle.kts
+++ b/android/stringmatcher/build.gradle.kts
@@ -8,8 +8,7 @@ dependencies {
     testImplementation(libs.kotlin.test)
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+extensions.configure<JavaPluginExtension> {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }


### PR DESCRIPTION
## 작업 영상

X

## 작업한 내용
- `java.toolchain` → `sourceCompatibility`,` targetCompatibility` 방식으로 마이그레이션

## PR 포인트

### 1). sourceCompatibility, targetCompatibility 으로 마이그레이션 으로 마이그레이션 이유

기존 `java.toolchain` 방식은 Gradle이 어떤 JDK 버전으로 `컴파일` 할지를 명시적으로 지정합니다.
결과적으로, 빌드 환경 자체를 JDK 17로 `강제`하게 됩니다.

이로 인해 해당 프로젝트를 사용하는 모든 개발자는 Gradle이 사용하는 **JDK를 반드시 17로 설치**를 요구하는 제약이 있습니다.

### 2). java.toolchain 21 설정으로 인해 발생한 이슈

제 로컬에는 JDK 17이 설치되어 있지 않아, 빌드 시 다음과 같은 오류가 발생했습니다.

![image](https://github.com/user-attachments/assets/d616c1fc-2779-463b-9088-1d19dcb3761d)



### 3). 제안

우리의 목적은 .class 파일을 Java `17` 바이트코드로 생성하는 것이지,
JDK 17 설치 자체를 강제하려는 건 아닙니다.

JDK 17 이상의 환경이라면 하위 호환이 가능하므로,
`sourceCompatibility / targetCompatibility` 방식이 더 유연한 선택이라 판단해 마이그레이션했습니다.

참고1). `sourceCompatibility` : 어떤 Java 문법 버전까지 허용할지
참고2). `targetCompatibility` : 어떤 버전의 .class 바이트코드를 생성할지

### 4). 한줄 요약

JDK 17 설치를 강제하기보다는,
하위 호환 가능한 컴파일 설정으로 유연하게 대응하기 위해 마이그레이션했습니다.

### 5). 참고 문헌

[sourceCompatibility, targetCompatibility, and JVM toolchains in Gradle explained](https://stefma.medium.com/sourcecompatibility-targetcompatibility-and-jvm-toolchains-in-gradle-explained-d2c17c8cff7c)

## 🚀Next Feature
- 포켓몬 리스트 홈 > onResume 에서 스크롤 초기화되는 이슈 수정
