### PR TITLE
[1.2.1/AN-Fix] 포켓몬 폼 형태 이름 중복해서 보이는 문제 해결

### DIFF
--- a/android/data/src/main/java/poke/rogue/helper/data/model/Pokemon.kt
+++ b/android/data/src/main/java/poke/rogue/helper/data/model/Pokemon.kt
@@ -53,28 +53,10 @@ fun PokemonResponse.toData(): Pokemon =
     )
 
 fun PokemonResponse2.toData(): Pokemon {
-    // TODO : 지금 포켓몬 이름을 보여주는거 모든 곳에서 통일이 안됨..
-    val pureName = name.substringBefore("_")
-    val pascalCaseFormName =
-        formName.split("_").joinToString("") { original ->
-            if (original.isBlank()) {
-                original
-            } else {
-                original.replaceFirstChar { it.uppercase() }
-            }
-        }
-
-    val formattedName =
-        if (formName.isBlank() || formName.trim().lowercase() == "normal") {
-            pureName
-        } else {
-            "$pureName-$pascalCaseFormName"
-        }
-
     return Pokemon(
         id = id,
         dexNumber = pokedexNumber,
-        name = formattedName,
+        name = name,
         formName = formName,
         imageUrl = image,
         backImageUrl = backImage,


### PR DESCRIPTION
- closed #477 

## 스크린 샷

- as is

<img width="255" alt="asIs_pokemon_list" src="https://github.com/user-attachments/assets/9cce37a8-1bce-4801-ae25-55e988050c66" />

- to be

<img width="252" alt="스크린샷 2025-04-07 오전 1 18 20" src="https://github.com/user-attachments/assets/86ab1a05-c821-4a5a-a43b-9c41432f3c3d" />

## 작업한 내용
- 포켓몬 폼 형태 이름 중복해서 보이는 문제가 있었음

## PR 포인트
- 서버에서 폼 이름 붙여서 보내주고 있음

## 🚀Next Feature
