### PR TITLE
[1.2.1/AN-FIX] 포켓몬 리스트 홈 > onResume 에서 스크롤 초기화되는 이슈 수정

### DIFF
--- a/android/app/src/androidTest/java/poke/rogue/helper/presentation/dex/PokemonListActivityTest.kt
+++ b/android/app/src/androidTest/java/poke/rogue/helper/presentation/dex/PokemonListActivityTest.kt
@@ -28,7 +28,7 @@ import poke.rogue.helper.testing.view.withItemCount
 class PokemonListActivityTest {
     @get:Rule
     val activityRule = activityScenarioRule<PokemonListActivity>()
-    val scenario get() = activityRule.scenario
+    private val scenario get() = activityRule.scenario
     private lateinit var idlingResource: IdlingResource
 
     @get:Rule
@@ -37,10 +37,12 @@ class PokemonListActivityTest {
             testViewModelModule,
         )
 
+    private lateinit var viewModel: PokemonListViewModel
+
     @Before
     fun setUp() {
         scenario.onActivity { activity ->
-            val viewModel = activity.getViewModel<PokemonListViewModel>()
+            viewModel = activity.getViewModel<PokemonListViewModel>()
 
             // StateFlow의 값이 비어 있지 않은 상태를 Idle로 간주
             idlingResource =
@@ -87,6 +89,17 @@ class PokemonListActivityTest {
         // scroll up
         onView(withId(R.id.root_pokemon_list))
             .perform(ViewActions.swipeDown())
+        onView(withId(R.id.header_group))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun `스크롤_down_후_포켓몬_검색_시_헤더그룹이_보인다`() {
+        onView(withId(R.id.root_pokemon_list))
+            .perform(ViewActions.swipeUp())
+
+        viewModel.queryName("이상해씨")
+
         onView(withId(R.id.header_group))
             .check(matches(isDisplayed()))
     }

--- a/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListActivity.kt
@@ -121,7 +121,7 @@ class PokemonListActivity :
         repeatOnStarted {
             viewModel.uiState.collect { uiState ->
                 pokemonAdapter.submitList(uiState.pokemons) {
-                    binding.rvPokemonList.scrollToPosition(0)
+                    scrollToTop()
                 }
 
                 binding.chipPokeFiter.bindPokeChip(
@@ -172,7 +172,7 @@ class PokemonListActivity :
             }
         }
     }
-    
+
     private fun initFragmentResultListeners() {
         supportFragmentManager.setFragmentResultListener(FILTER_RESULT_KEY, this) { key, bundle ->
             val filterArgs: PokeFilterUiModel =
@@ -180,7 +180,7 @@ class PokemonListActivity :
                     ?: return@setFragmentResultListener
             viewModel.filterPokemon(filterArgs)
         }
-        
+
         supportFragmentManager.setFragmentResultListener(SORT_RESULT_KEY, this) { key, bundle ->
             val sortArgs: PokemonSortUiModel =
                 PokemonSortBottomSheetFragment.argsFrom(bundle)
@@ -191,18 +191,17 @@ class PokemonListActivity :
 
     private fun initClickListeners() {
         binding.btnPokeListScrollUp.setOnClickListener {
-            binding.rvPokemonList.scrollToPosition(0)
-            binding.appBarPokemonList.setExpanded(true, true)
+            scrollToTop()
         }
         binding.root.setOnClickListener {
             hideKeyboard()
         }
     }
 
-    private fun String.clean() =
-        this
-            .replace("\\s".toRegex(), "")
-            .replace("[^a-zA-Z0-9ㄱ-ㅎ가-힣]".toRegex(), "")
+    private fun scrollToTop() {
+        binding.rvPokemonList.scrollToPosition(0)
+        binding.appBarPokemonList.setExpanded(true, true)
+    }
 
     companion object {
         const val FILTER_RESULT_KEY = "FILTER_RESULT_KEY_result_key"

--- a/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListActivity.kt
@@ -48,8 +48,10 @@ class PokemonListActivity :
         binding.vm = viewModel
         binding.lifecycleOwner = this
         initAdapter()
-        initObservers()
-        initListeners()
+        observeUiState()
+        observeUiEvent()
+        initClickListeners()
+        initFragmentResultListeners()
     }
 
     private fun initAdapter() {
@@ -115,7 +117,7 @@ class PokemonListActivity :
         }
     }
 
-    private fun initObservers() {
+    private fun observeUiState() {
         repeatOnStarted {
             viewModel.uiState.collect { uiState ->
                 pokemonAdapter.submitList(uiState.pokemons) {
@@ -160,19 +162,25 @@ class PokemonListActivity :
                 )
             }
         }
+    }
+
+    private fun observeUiEvent() {
         repeatOnStarted {
             viewModel.navigateToDetailEvent.collect { pokemonId ->
                 hideKeyboard()
                 startActivity(PokemonDetailActivity.intent(this, pokemonId))
             }
         }
-
+    }
+    
+    private fun initFragmentResultListeners() {
         supportFragmentManager.setFragmentResultListener(FILTER_RESULT_KEY, this) { key, bundle ->
             val filterArgs: PokeFilterUiModel =
                 PokemonFilterBottomSheetFragment.argsFrom(bundle)
                     ?: return@setFragmentResultListener
             viewModel.filterPokemon(filterArgs)
         }
+        
         supportFragmentManager.setFragmentResultListener(SORT_RESULT_KEY, this) { key, bundle ->
             val sortArgs: PokemonSortUiModel =
                 PokemonSortBottomSheetFragment.argsFrom(bundle)
@@ -181,7 +189,7 @@ class PokemonListActivity :
         }
     }
 
-    private fun initListeners() {
+    private fun initClickListeners() {
         binding.btnPokeListScrollUp.setOnClickListener {
             binding.rvPokemonList.scrollToPosition(0)
             binding.appBarPokemonList.setExpanded(true, true)

--- a/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListActivity.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListActivity.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.animation.AnimationUtils
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.doOnNextLayout
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
@@ -120,9 +121,7 @@ class PokemonListActivity :
     private fun observeUiState() {
         repeatOnStarted {
             viewModel.uiState.collect { uiState ->
-                pokemonAdapter.submitList(uiState.pokemons) {
-                    scrollToTop()
-                }
+                pokemonAdapter.submitList(uiState.pokemons)
 
                 binding.chipPokeFiter.bindPokeChip(
                     PokeChip.Spec(
@@ -166,9 +165,17 @@ class PokemonListActivity :
 
     private fun observeUiEvent() {
         repeatOnStarted {
-            viewModel.navigateToDetailEvent.collect { pokemonId ->
-                hideKeyboard()
-                startActivity(PokemonDetailActivity.intent(this, pokemonId))
+            viewModel.uiEvent.collect { uiEvent ->
+                when (uiEvent) {
+                    is PokemonListUiEvent.NavigateToHome -> {
+                        hideKeyboard()
+                        startActivity(PokemonDetailActivity.intent(this, uiEvent.pokemonId))
+                    }
+
+                    is PokemonListUiEvent.ChangeSearchOption -> {
+                        scrollToTop()
+                    }
+                }
             }
         }
     }
@@ -199,7 +206,9 @@ class PokemonListActivity :
     }
 
     private fun scrollToTop() {
-        binding.rvPokemonList.scrollToPosition(0)
+        binding.rvPokemonList.doOnNextLayout {
+            binding.rvPokemonList.scrollToPosition(0)
+        }
         binding.appBarPokemonList.setExpanded(true, true)
     }
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListViewModel.kt
@@ -37,7 +37,7 @@ import poke.rogue.helper.presentation.type.model.toData
 
 class PokemonListViewModel(
     private val pokemonRepository: DexRepository,
-    logger: AnalyticsLogger = analyticsLogger(),
+    private val logger: AnalyticsLogger = analyticsLogger(),
 ) : ErrorHandleViewModel(logger), PokemonListNavigateHandler, PokemonQueryHandler {
     private val searchQuery = MutableStateFlow("")
     private val pokeFilter =
@@ -136,7 +136,7 @@ class PokemonListViewModel(
             pokeFilter.value = filter
             _uiEvent.send(PokemonListUiEvent.ChangeSearchOption)
         }
-        analyticsLogger().logPokemonFilter(filter)
+        logger.logPokemonFilter(filter)
     }
 
     fun sortPokemon(sort: PokemonSortUiModel) {
@@ -144,7 +144,7 @@ class PokemonListViewModel(
             pokeSort.value = sort
             _uiEvent.send(PokemonListUiEvent.ChangeSearchOption)
         }
-        analyticsLogger().logPokemonSort(sort)
+        logger.logPokemonSort(sort)
     }
 }
 

--- a/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListViewModel.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/dex/PokemonListViewModel.kt
@@ -3,11 +3,11 @@ package poke.rogue.helper.presentation.dex
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -89,8 +90,8 @@ class PokemonListViewModel(
                 true,
             )
 
-    private val _navigateToDetailEvent = MutableSharedFlow<String>()
-    val navigateToDetailEvent = _navigateToDetailEvent.asSharedFlow()
+    private val _uiEvent = Channel<PokemonListUiEvent>(capacity = Channel.BUFFERED)
+    val uiEvent: Flow<PokemonListUiEvent> = _uiEvent.receiveAsFlow()
 
     private suspend fun queriedPokemons(
         query: String,
@@ -119,19 +120,21 @@ class PokemonListViewModel(
 
     override fun navigateToPokemonDetail(pokemonId: String) {
         viewModelScope.launch {
-            _navigateToDetailEvent.emit(pokemonId)
+            _uiEvent.send(PokemonListUiEvent.NavigateToHome(pokemonId))
         }
     }
 
     override fun queryName(name: String) {
         viewModelScope.launch {
             searchQuery.value = name
+            _uiEvent.send(PokemonListUiEvent.ChangeSearchOption)
         }
     }
 
     fun filterPokemon(filter: PokeFilterUiModel) {
         viewModelScope.launch {
             pokeFilter.value = filter
+            _uiEvent.send(PokemonListUiEvent.ChangeSearchOption)
         }
         analyticsLogger().logPokemonFilter(filter)
     }
@@ -139,6 +142,7 @@ class PokemonListViewModel(
     fun sortPokemon(sort: PokemonSortUiModel) {
         viewModelScope.launch {
             pokeSort.value = sort
+            _uiEvent.send(PokemonListUiEvent.ChangeSearchOption)
         }
         analyticsLogger().logPokemonSort(sort)
     }
@@ -161,4 +165,10 @@ data class PokemonListUiState(
                 if (filteredGeneration != PokeGenerationUiModel.ALL) count++
                 count
             }
+}
+
+sealed interface PokemonListUiEvent {
+    data class NavigateToHome(val pokemonId: String) : PokemonListUiEvent
+
+    data object ChangeSearchOption : PokemonListUiEvent
 }

--- a/android/app/src/test/java/poke/rogue/helper/presentation/dex/PokemonListActivityTest.kt
+++ b/android/app/src/test/java/poke/rogue/helper/presentation/dex/PokemonListActivityTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.koin.androidx.viewmodel.ext.android.getViewModel
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
 import poke.rogue.helper.R
@@ -26,7 +27,7 @@ import poke.rogue.helper.testing.view.withItemCount
 class PokemonListActivityTest {
     @get:Rule
     val activityRule = activityScenarioRule<PokemonListActivity>()
-    val scenario get() = activityRule.scenario
+    private val scenario get() = activityRule.scenario
 
     @get:Rule
     val koinTestRule =
@@ -34,8 +35,14 @@ class PokemonListActivityTest {
             testViewModelModule,
         )
 
+    lateinit var viewModel: PokemonListViewModel
+
     @Before
     fun setUp() {
+        scenario.onActivity { activity ->
+            viewModel = activity.getViewModel()
+        }
+
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
     }
 
@@ -68,6 +75,17 @@ class PokemonListActivityTest {
         // scroll up
         onView(withId(R.id.root_pokemon_list))
             .perform(ViewActions.swipeDown())
+        onView(withId(R.id.header_group))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun `스크롤 down 후 포켓몬 검색 시 헤더 그룹이 보인다`() {
+        onView(withId(R.id.root_pokemon_list))
+            .perform(ViewActions.swipeUp())
+
+        viewModel.queryName("이상해씨")
+
         onView(withId(R.id.header_group))
             .check(matches(isDisplayed()))
     }


### PR DESCRIPTION
- closed #495
## 작업 영상

## 작업한 내용
-

## PR 포인트
- NavigationEvent > UiEvent 로 통일
    - Channel 을 사용하여 UiEvent 처리했습니다.
- debounce 때문에 스크롤이 안먹는 이슈가 있었음.
  - `doOnNextLayout {}` 을 활용하여 리사이클러뷰가 다음 `layout()`단계에 진입할 때 최상단으로 스크롤하도록 예약함
- initobeservers 이 너무 길어져서 더 잘게 함수로 쪼갰습니다.

## 🚀Next Feature
