### PR TITLE
[1.2.1/AN-FIX] 앱 이름 구분을 위한 스트링 리소스 편집

### DIFF
--- a/android/app/src/main/res/values-ko-rKR/strings.xml
+++ b/android/app/src/main/res/values-ko-rKR/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">PokéRogue Helper</string>
     <!-- type -->
     <string name="type_title_name">타입 상성</string>
     <string name="type_my_type_title">내 타입</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">PokéRogue Helper</string>
     <!-- type -->
     <string name="type_title_name">Type Matchups</string>
     <string name="type_my_type_title">My Type</string>


### PR DESCRIPTION
- closed #506 
## 작업 영상

작업 이전: 
<img width="151" alt="image" src="https://github.com/user-attachments/assets/5dde5fa6-cebb-4ea3-95f9-c2ea3734ff69" />

작업 후:
<img width="151" alt="image" src="https://github.com/user-attachments/assets/0aa4ce3e-ded5-45a4-b9f7-b2f724f7acad" />

## 작업한 내용
- 문제 원인: 
  - 국제화를 적용하면서 리소스를 찾을 때 우선순위가 바뀌어서 아래와 같은 일이 벌어졌습니다.
  - strings.xml 의 우선순위 문제 떄문에 Manifest 에서 앱 이름을 선택할 때  `app/src/alpha/res/values/strings.xml` 나 `app/src/debug/res/values/strings.xml` 등을 선택하지 않고 `app/src/main/res/values-ko-rKR/strings.xml` 혹은 `app/src/main/res/values/strings.xml` 를 선택.
- 해결 방법:
  - app_name 에 대해서 app/src/alpha/res/values/strings.xml 혹은 app/src/main/res/values-ko-rKR/strings.xml 를 참조하지 않도록 위 파일들의 app_name 스트링 리소스 제거.

## PR 포인트
- 그런건 없어요~

## 🚀Next Feature
- API 통신 시 헤더에 로케일 정보 넣어서 보내기
