### PR TITLE
[1.2.1/AN-FEAT] 로컬라이징 - 클라이언트 로케일 헤더 전송 기능 추가

### DIFF
--- a/android/remote/src/main/java/poke/rogue/helper/remote/di/RetrofitModule.kt
+++ b/android/remote/src/main/java/poke/rogue/helper/remote/di/RetrofitModule.kt
@@ -10,6 +10,7 @@ import org.koin.dsl.module
 import poke.rogue.helper.remote.BuildConfig
 import poke.rogue.helper.remote.injector.PokeCallAdapterFactory
 import poke.rogue.helper.remote.injector.PokeConverterFactory
+import poke.rogue.helper.remote.interceptor.LocaleInterceptor
 import poke.rogue.helper.remote.interceptor.RedirectInterceptor
 import retrofit2.Converter
 import retrofit2.Retrofit
@@ -47,12 +48,14 @@ internal val retrofitModule
             single { (redirectUrl: String) ->
                 RedirectInterceptor(redirectUrl)
             }
+            singleOf(::LocaleInterceptor)
             singleOf(::PokeCallAdapterFactory)
             singleOf(::PokeConverterFactory)
 
             single<OkHttpClient> {
                 OkHttpClient
                     .Builder()
+                    .addInterceptor(get<LocaleInterceptor>())
                     .addInterceptor(get<HttpLoggingInterceptor>())
                     .let { client ->
                         if (BuildConfig.DEBUG) {

--- a/android/remote/src/main/java/poke/rogue/helper/remote/interceptor/LocaleInterceptor.kt
+++ b/android/remote/src/main/java/poke/rogue/helper/remote/interceptor/LocaleInterceptor.kt
@@ -1,0 +1,17 @@
+package poke.rogue.helper.remote.interceptor
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.Locale
+
+class LocaleInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val localeCode = Locale.getDefault().toLanguageTag()
+        val request =
+            chain.request().newBuilder()
+                .addHeader("Accept-Language", localeCode)
+                .build()
+
+        return chain.proceed(request)
+    }
+}

--- a/android/remote/src/test/java/poke/rogue/helper/remote/interceptor/LocaleInterceptorTest.kt
+++ b/android/remote/src/test/java/poke/rogue/helper/remote/interceptor/LocaleInterceptorTest.kt
@@ -1,0 +1,49 @@
+package poke.rogue.helper.remote.interceptor
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import java.util.Locale
+
+class LocaleInterceptorTest : BehaviorSpec({
+
+    val mockWebServer = MockWebServer()
+
+    beforeSpec {
+        mockWebServer.start()
+    }
+
+    afterSpec {
+        mockWebServer.shutdown()
+    }
+
+    Given("디바이스가 언어는 한국어로, 지역은 한국으로 설정되어 있다.") {
+        val locale = Locale("ko", "KR")
+        Locale.setDefault(locale)
+
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor(LocaleInterceptor())
+                .build()
+
+        val request =
+            Request.Builder()
+                .url(mockWebServer.url("/test"))
+                .build()
+
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+        When("요청이 불릴 때") {
+            client.newCall(request).execute()
+
+            Then("헤더에 들어가는 Accept-Language 는 ko-KR 이다.") {
+                val recordedRequest = mockWebServer.takeRequest()
+                val headerValue = recordedRequest.getHeader("Accept-Language")
+                headerValue shouldBe "ko-KR"
+            }
+        }
+    }
+})

--- a/android/remote/src/test/java/poke/rogue/helper/remote/interceptor/LocaleInterceptorTest.kt
+++ b/android/remote/src/test/java/poke/rogue/helper/remote/interceptor/LocaleInterceptorTest.kt
@@ -1,6 +1,10 @@
 package poke.rogue.helper.remote.interceptor
 
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.data.forAll
+import io.kotest.data.headers
+import io.kotest.data.row
+import io.kotest.data.table
 import io.kotest.matchers.shouldBe
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -20,29 +24,34 @@ class LocaleInterceptorTest : BehaviorSpec({
         mockWebServer.shutdown()
     }
 
-    Given("디바이스가 언어는 한국어로, 지역은 한국으로 설정되어 있다.") {
-        val locale = Locale("ko", "KR")
-        Locale.setDefault(locale)
+    forAll(
+        table(
+            headers("description", "testLocale", "expectedHeader"),
+            row("ko-KR", Locale("ko", "KR"), "ko-KR"),
+            row("en-US", Locale("en", "US"), "en-US"),
+        ),
+    ) { description, testLocale, expectedHeader ->
+        Given("디바이스 로케일이 $description 일 때") {
+            Locale.setDefault(testLocale)
 
-        val client =
-            OkHttpClient.Builder()
-                .addInterceptor(LocaleInterceptor())
-                .build()
+            val client =
+                OkHttpClient.Builder()
+                    .addInterceptor(LocaleInterceptor())
+                    .build()
+            val request =
+                Request.Builder()
+                    .url(mockWebServer.url("/test"))
+                    .build()
+            mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-        val request =
-            Request.Builder()
-                .url(mockWebServer.url("/test"))
-                .build()
+            When("api 요청이 불릴 때") {
+                client.newCall(request).execute()
 
-        mockWebServer.enqueue(MockResponse().setResponseCode(200))
-
-        When("요청이 불릴 때") {
-            client.newCall(request).execute()
-
-            Then("헤더에 들어가는 Accept-Language 는 ko-KR 이다.") {
-                val recordedRequest = mockWebServer.takeRequest()
-                val headerValue = recordedRequest.getHeader("Accept-Language")
-                headerValue shouldBe "ko-KR"
+                Then("헤더에 들어가는 Accept-Language 는 $expectedHeader 이다.") {
+                    val recordedRequest = mockWebServer.takeRequest()
+                    val headerValue = recordedRequest.getHeader("Accept-Language")
+                    headerValue shouldBe expectedHeader
+                }
             }
         }
     }


### PR DESCRIPTION
- closed #499 
## 작업 영상
X

## 작업한 내용
- 헤더에 로케일 정보를 넣는 인터셉터 클래스를 생성, retrofitModule 에서 인터셉터를 추가한다.
- 헤더에는 키: `Accept-Language` 값은 [BCP 47](https://docs.oracle.com/javase/tutorial/i18n/locale/extensions.html) 형식으로 설정한다.
  -  한국어, 한국 기준 `ko-KR`  으로 설정한다.
- kotest 와 mockWebServer 를 이용해서 테스트 코드 작성한다.  [forAll api](https://kotest.io/docs/proptest/property-test-functions.html#for-all)

## PR 포인트
- 안드로이드 의존성 없이, Java 의 `Locale` api 만으로도 대응이 가능해서 remote 모듈에서 바로 Locale 을 얻어왔습니다.
  - 이 api 는 자바 7 이상부터 사용 가능.
- `ko-KR` 설명
  - **일반적으로는 `<language>` 만 사용하면 되지만, 혹시나 나중에 언어는 같지만, 지역/국가 가 다를 때 다르게 대응해야 할 요구사항이 바뀔 수도 있으니, `<language>-<region>` 형태로 보냅니다.(서버에서는 이 부분만 참고하세요)**
  - 갤럭시 기기 기준으로 <language> 는 설정 - 일반 - 언어 순으로 들어가서 언어 변경 시에 실제로 바뀐다.
  - 갤럭시 기기 기준으로 명확하게 “국가”를 바꾸는 항목은 없지만, 시간대(Timezone) 변경을 통해 지역 간접 설정하여 <region> 을 변경할 수 있다.
  - 예: 미국 LA 의 타임 존에 있는 상태에서 기기 언어 설정만 한국어로 하면, LocaleCode 가 `ko-US`

참고: `<language>-<region>` 안드로이드에서는 국제화 시에 리소스 파일을 다음과 같이 생성할 수 있다(`ko-rKR`). 안드로이드에서만 `-` 뒤에 r 이 붙는다. (region 을 나타내기 위함)

## 🚀Next Feature

영어로 포켓몬 검색 시 로직 변경
