### PR TITLE
[1.2.1/AN-FIX] 화면 회전 시 Glide 이미지 캐시로 인해 progressIndicator가 사라지지 않는 문제 해결

### DIFF
--- a/android/app/src/main/java/poke/rogue/helper/presentation/util/view/CommonBindingAdapter.kt
+++ b/android/app/src/main/java/poke/rogue/helper/presentation/util/view/CommonBindingAdapter.kt
@@ -1,5 +1,6 @@
 package poke.rogue.helper.presentation.util.view
 
+import android.content.Context
 import android.view.View
 import android.widget.ImageView
 import androidx.annotation.ColorRes
@@ -54,13 +55,37 @@ fun ImageView.loadImageWithProgress(
     imageUrl: String?,
     progressIndicator: CircularProgressIndicator,
 ) {
-    progressIndicator.visibility = View.VISIBLE
+    val glideRequest =
+        Glide.with(context)
+            .load(imageUrl)
+            .error(R.drawable.ic_ditto_silhouette)
 
-    Glide.with(context)
-        .load(imageUrl)
+    if (isImageCached(context, imageUrl)) {
+        progressIndicator.visibility = View.GONE
+        glideRequest.into(this)
+        return
+    }
+
+    progressIndicator.visibility = View.VISIBLE
+    glideRequest
         .listener(createProgressListener(progressIndicator))
-        .error(R.drawable.ic_ditto_silhouette)
         .into(this)
+}
+
+private fun isImageCached(
+    context: Context,
+    url: String?,
+): Boolean {
+    return try {
+        val futureTarget =
+            Glide.with(context)
+                .load(url)
+                .onlyRetrieveFromCache(true)
+                .submit()
+        futureTarget.get() != null
+    } catch (_: Exception) {
+        false
+    }
 }
 
 @BindingAdapter("imageRes")


### PR DESCRIPTION
 closed #503 
## 작업 영상

| 버그 발생 전 | 버그 수정 후 |
|--------------|--------------|
| <video src="https://github.com/user-attachments/assets/f529325b-f655-4161-978a-71a36fd4f8c4" width="300" controls /> | <video src="https://github.com/user-attachments/assets/f8592f9a-8678-4e05-a55b-beb7db71d3f1" width="300" controls /> |

---



## 작업한 내용

- **문제점**  
  - 가로 모드에서 이미지를 로드한 후 세로 모드로 회전할 경우, Glide의 캐시로 인해 이미지는 즉시 표시되지만 `progressIndicator`는 계속 남아 있는 문제가 발생했습니다.  
  - 이는 **Glide가 캐시에서 이미지를 불러올 경우, 로딩 완료 콜백이 호출되지 않아** 인디케이터가 숨겨지지 않는 현상 때문이었습니다.

- **해결 방법**  
  - `BindingAdapter`의 `loadImageWithProgress` 함수 내부에서 Glide 요청 전 `isImageCached(context, url)`을 호출해 캐시 여부를 사전 체크.  
  - 캐시된 이미지인 경우, 로딩 시작 전에 **`progressIndicator.visibility = View.GONE`** 처리로 UI 상태를 미리 반영.  
  - 기존 Glide listener(`createProgressListener`)도 유지하여 일반적인 로딩 흐름도 함께 처리.

## PR 포인트
- 그런 건 없어요

## 🚀Next Feature
- 아마 영어 검색 로직 변경?
