### PR TITLE
[1.2.1/AN-FIX] Crashlytics 로그 안찍히는 이슈 해결

### DIFF
--- a/android/analytics/src/main/java/poke/rogue/helper/analytics/FireBaseAnalyticsLogger.kt
+++ b/android/analytics/src/main/java/poke/rogue/helper/analytics/FireBaseAnalyticsLogger.kt
@@ -25,7 +25,9 @@ internal object FireBaseAnalyticsLogger : AnalyticsLogger {
         message: String?,
     ) {
         analyticsScope.launch {
-            message ?: Firebase.crashlytics.log("Error: $message")
+            message?.let {
+                Firebase.crashlytics.log("Error: $message")
+            }
             Firebase.crashlytics.recordException(throwable)
         }
     }


### PR DESCRIPTION
- closed #이슈넘버
## 작업 영상

- 로그 찍히는거 확인

![image](https://github.com/user-attachments/assets/11363e87-09a9-4746-970e-bf48a82832eb)


## 작업한 내용
-  Crashlytics 로그 안찍히는 이슈 해결

## PR 포인트
- message가 null 인 경우에 crashlytics 로그를 찍고 있어서 수정

- tmi). 회사에서 crashlytics `recordException()`이랑 `log()`  찍을 일이 있어서 포케로그로 먼저 테스트해봤는데.. 잘못 찍고 있더라구요 그래서 수정했습니다!

## 🚀Next Feature
- 1.2.1 릴리즈하기