### PR TITLE
[1.2.1/AN-FIX] AAB 추출 오류 및 빌드 변형 앱 이름 설정 문제 해결

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -54,6 +54,7 @@ android {
         debug {
             applicationIdSuffix = ".dev"
             signingConfig = signingConfigs.getByName("debug")
+            resValue("string", "app_name", "Dev PokéRogue Helper")
         }
 
         create("beta") {
@@ -61,6 +62,7 @@ android {
             versionNameSuffix = "-beta"
             applicationIdSuffix = ".beta"
             signingConfig = signingConfigs.getByName("debug")
+            resValue("string", "app_name", "Beta PokéRogue Helper")
 //            firebaseAppDistribution {
 //                artifactType = "APK"
 //                releaseNotesFile = "firebase/releaseNote.txt"
@@ -73,6 +75,7 @@ android {
             versionNameSuffix = "-alpha"
             applicationIdSuffix = ".alpha"
             signingConfig = signingConfigs.getByName("debug")
+            resValue("string", "app_name", "Alpha PokéRogue Helper")
 //            firebaseAppDistribution {
 //                artifactType = "APK"
 //                releaseNotesFile = "firebase/releaseNote.txt"

--- a/android/app/src/main/res/values-ko-rKR/strings.xml
+++ b/android/app/src/main/res/values-ko-rKR/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="app_name">PokéRogue Helper</string>
     <!-- type -->
     <string name="type_title_name">타입 상성</string>
     <string name="type_my_type_title">내 타입</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="app_name">PokéRogue Helper</string>
     <!-- type -->
     <string name="type_title_name">Type Matchups</string>
     <string name="type_my_type_title">My Type</string>


### PR DESCRIPTION
## 작업 영상
NO

## 작업한 내용
- https://github.com/woowacourse-teams/2024-pokerogue-helper/pull/507 에서 제가 수정한 부분 때문에 aab 로 추출이 안되는 거였습니다.
- 이전에 국제화(Localization) 우선순위 문제 때문에 `app/src/main/res/values/strings.xml`에서 `app_name` 리소스를 제거했습니다.
- 이로 인해 `release` 빌드가 앱 이름을 찾지 못해 `.aab` 파일 추출이 실패하는 문제가 발생했습니다.
- `app/build.gradle.kts` 파일에 **`resValue`**를 추가하여 빌드 스크립트에서 직접 앱 이름을 주입하는 방식으로 문제를 해결했습니다.

## PR 포인트
- `app/build.gradle.kts`에 `debug`, `alpha`, `beta` 빌드 타입에 대한 `resValue` 추가
- `app/src/main/res/values/strings.xml`에 `app_name` 리소스 복원
- 아마 이 문제 대문에 릴리즈가 안되었던 게 아닌 가 싶네요, 🙈

## 🚀Next Feature
- baseURL 변경
